### PR TITLE
refactor:  `vaadin-accordion[theme~=cxl-accordion-card] as grid

### DIFF
--- a/packages/cxl-lumo-styles/scss/themes/cxl-accordion-card.scss
+++ b/packages/cxl-lumo-styles/scss/themes/cxl-accordion-card.scss
@@ -1,4 +1,5 @@
 :host {
+  position: relative;
   padding: var(--lumo-space-m);
   margin-top: var(--lumo-space-m);
   margin-bottom: var(--lumo-space-m);
@@ -7,12 +8,17 @@
   border: 1px solid var(--lumo-shade-10pct);
   border-radius: var(--lumo-border-radius-s);
   box-shadow: var(--lumo-box-shadow-xs);
-  break-inside: avoid;
   transform: translateZ(0); // @see https://stackoverflow.com/a/55110789/35946
 }
 
 :host(:hover) {
+  z-index: 3;
   border-color: var(--lumo-primary-color);
+  box-shadow: var(--lumo-box-shadow-s);
+}
+
+:host(:hover:last-child) {
+  border-bottom: 1px solid var(--lumo-primary-color); // Overrides vaadin-accordion-panel default, because all items match last-child in grid layout
 }
 
 :host(:not[disabled]) {
@@ -32,11 +38,17 @@
 }
 
 :host([opened]) {
+  z-index: 1;
   border-color: var(--lumo-primary-color);
+  box-shadow: var(--lumo-box-shadow-s);
 
   [part="toggle"] {
     transform: rotate(180deg);
   }
+}
+
+:host([opened]:hover) {
+  z-index: 2;
 }
 
 :host([theme~="dark"]) {

--- a/packages/cxl-lumo-styles/scss/themes/vaadin-accordion.scss
+++ b/packages/cxl-lumo-styles/scss/themes/vaadin-accordion.scss
@@ -1,5 +1,8 @@
 :host([theme~="cxl-accordion-card"]) {
-  column-gap: calc(var(--lumo-space-m) * 2);
-  column-rule: 1px solid var(--lumo-shade-10pct); // match panel `outline`
-  column-width: calc(var(--lumo-space-m) * 18);
+  display: grid;
+  max-width: 100vw;
+  grid-template-columns: repeat(auto-fill, minmax(calc(var(--lumo-space-m) * 21), 1fr));
+  grid-template-rows: repeat(auto-fill, calc(var(--lumo-space-m) * 16));
+  gap: calc(var(--lumo-space-m) * 2);
+  grid-auto-flow: row;
 }

--- a/packages/storybook/cxl-ui/cxl-vaadin-accordion/cxl-accordion-card.stories.js
+++ b/packages/storybook/cxl-ui/cxl-vaadin-accordion/cxl-accordion-card.stories.js
@@ -9,21 +9,22 @@ export default {
 };
 
 export const CxlVaadinAccordionThemeArchive = () => {
-  let lastEntryTitle1stLetter = 'Z';
+  // TEMPORARILY UNUSED LETTER HEADINGS HELPER FUNCTION
+  // let lastEntryTitle1stLetter = 'Z';
+  
+  // const firstLetterHeading = el => {
+  //   const firstLetter = el.title.raw.charAt(0);
+  //   let heading = html``;
 
-  const firstLetterHeading = el => {
-    const firstLetter = el.title.raw.charAt(0);
-    let heading = html``;
+  //   if (firstLetter !== lastEntryTitle1stLetter) {
+  //     heading = html`
+  //       <h3 id="letter-${firstLetter}" class='letter-heading'>${firstLetter}</h3>
+  //     `;
+  //     lastEntryTitle1stLetter = firstLetter;
+  //   }
 
-    if (firstLetter !== lastEntryTitle1stLetter) {
-      heading = html`
-        <h3 id="letter-${firstLetter}" class='letter-heading'>${firstLetter}</h3>
-      `;
-      lastEntryTitle1stLetter = firstLetter;
-    }
-
-    return heading;
-  };
+  //   return heading;
+  // };
 
   return html`
     <style>
@@ -54,7 +55,6 @@ export const CxlVaadinAccordionThemeArchive = () => {
     >
       ${archiveData.map(
         el => html`
-          ${firstLetterHeading(el)}
           <div class='card-wrapper'>
             <cxl-accordion-card
               id="${el.cxl_hybrid_attr_post['@attributes'].id}"

--- a/packages/storybook/cxl-ui/cxl-vaadin-accordion/cxl-accordion-card.stories.js
+++ b/packages/storybook/cxl-ui/cxl-vaadin-accordion/cxl-accordion-card.stories.js
@@ -17,7 +17,7 @@ export const CxlVaadinAccordionThemeArchive = () => {
 
     if (firstLetter !== lastEntryTitle1stLetter) {
       heading = html`
-        <h3 id="letter-${firstLetter}">${firstLetter}</h3>
+        <h3 id="letter-${firstLetter}" class='letter-heading'>${firstLetter}</h3>
       `;
       lastEntryTitle1stLetter = firstLetter;
     }
@@ -36,6 +36,16 @@ export const CxlVaadinAccordionThemeArchive = () => {
       .entry-title a {
         color: inherit;
       }
+      /* These are necessary to make the Grid Layout work properly */
+      .letter-heading {
+        padding: 0 10px;
+        grid-column-start: 1;
+      }
+      .card-wrapper {
+        height: calc(var(--lumo-space-m) * 16);
+        padding: var(--lumo-space-s);
+        overflow: visible;
+      }
     </style>
     <cxl-vaadin-accordion
       id="cxl-vaadin-accordion-26107"
@@ -45,48 +55,50 @@ export const CxlVaadinAccordionThemeArchive = () => {
       ${archiveData.map(
         el => html`
           ${firstLetterHeading(el)}
-          <cxl-accordion-card
-            id="${el.cxl_hybrid_attr_post['@attributes'].id}"
-            class="${el.cxl_hybrid_attr_post['@attributes'].class}"
-            theme="${el.cxl_hybrid_attr_post['@attributes'].class.includes(
-              'category-minidegree-programs'
-            )
-              ? 'dark'
-              : ''}"
-          >
-            <header class="entry-header" slot="summary">
-              <h3 class="entry-title no-anchor" itemprop="headline">
-                <a href="${el.conversionxl_certificate_sales_page}" rel="bookmark" itemprop="url"
-                  >${el.title.raw}</a
-                >
-              </h3>
-              <a href="${el.conversionxl_certificate_sales_page}" rel="bookmark" itemprop="url">
-                <img
-                  class="landscape cw-greater thumbnail shop_catalog lazyloaded"
-                  alt="${el.title.raw}"
-                  itemprop="image"
-                  src="${el.cxl_featured_media.shop_catalog}"
-                  data-src="${el.cxl_featured_media.shop_catalog}"
-                  loading="lazy"
-                  width="150"
-                  height="150"
-                />
-              </a>
-              <div class="entry-byline">
-                <iron-icon icon="lumo:clock"></iron-icon>${el.conversionxl_live_course_duration}
-                <hr />
-                Instructors: ${el.conversionxl_certificate_instructor}
+          <div class='card-wrapper'>
+            <cxl-accordion-card
+              id="${el.cxl_hybrid_attr_post['@attributes'].id}"
+              class="${el.cxl_hybrid_attr_post['@attributes'].class}"
+              theme="${el.cxl_hybrid_attr_post['@attributes'].class.includes(
+                'category-minidegree-programs'
+              )
+                ? 'dark'
+                : ''}"
+            >
+              <header class="entry-header" slot="summary">
+                <h3 class="entry-title no-anchor" itemprop="headline">
+                  <a href="${el.conversionxl_certificate_sales_page}" rel="bookmark" itemprop="url"
+                    >${el.title.raw}</a
+                  >
+                </h3>
+                <a href="${el.conversionxl_certificate_sales_page}" rel="bookmark" itemprop="url">
+                  <img
+                    class="landscape cw-greater thumbnail shop_catalog lazyloaded"
+                    alt="${el.title.raw}"
+                    itemprop="image"
+                    src="${el.cxl_featured_media.shop_catalog}"
+                    data-src="${el.cxl_featured_media.shop_catalog}"
+                    loading="lazy"
+                    width="150"
+                    height="150"
+                  />
+                </a>
+                <div class="entry-byline">
+                  <iron-icon icon="lumo:clock"></iron-icon>${el.conversionxl_live_course_duration}
+                  <hr />
+                  Instructors: ${el.conversionxl_certificate_instructor}
+                </div>
+              </header>
+              <div class="entry-summary" itemprop="description">
+                ${unsafeHTML(el.content.cxl_get_extended_main)}
               </div>
-            </header>
-            <div class="entry-summary" itemprop="description">
-              ${unsafeHTML(el.content.cxl_get_extended_main)}
-            </div>
-            <div class="entry-footer" style="text-align: right;">
-              <a href="${el.conversionxl_certificate_sales_page}"
-                >View training<iron-icon icon="lumo:angle-right"></iron-icon
-              ></a>
-            </div>
-          </cxl-accordion-card>
+              <div class="entry-footer" style="text-align: right;">
+                <a href="${el.conversionxl_certificate_sales_page}"
+                  >View training<iron-icon icon="lumo:angle-right"></iron-icon
+                ></a>
+              </div>
+            </cxl-accordion-card>
+          </div>
         `
       )}
     </cxl-vaadin-accordion>


### PR DESCRIPTION
This is probably the best we can do with a Grid Layout (issue  #48).
Observations:
- using the column flow (via grid-auto-flow: column) causes the layout to break in weird ways. It ends up being one long rows, even when rows are not left as auto
- Setting a height to the accordion element "fixes" it. But that's not practical, as we have to calculate the best height from the number of elements using JS 
- setting seemingly unrelated properties, like making all Letter headings grid-colum-start: 1, also affect the row issues, as a side effect. Is this case that's because each letter heading needs it's own row, which forces the browser to add rows to the grid. 
- overflowing cards resolve the grid cells changing height, but stacking context creates a different challenge. I resolved it by making sure the cards have their own stacking contexts, and that opened and hovered cards have higher z-index.
- This layout _needs_ a wrapper around each card and css applied to the letter headings. That was done in the stories file, as a proof of concept, but we can find ways to incorporate that in vaadin-accordion and cxl-accordion-card elements.
 
This is the current result.  I'm also working on another branch to present a flex version. It's not ready though, and I think Grid still looks more promising. 

<img width="1451" alt="Screen Shot 2020-04-20 at 17 04 26" src="https://user-images.githubusercontent.com/1887825/79794661-050f2d80-8329-11ea-83e8-6e800c6f1126.png">
 