### PR TITLE
style: Improve font size responsiveness (issue #55)

### DIFF
--- a/packages/cxl-lumo-styles/scss/typography.scss
+++ b/packages/cxl-lumo-styles/scss/typography.scss
@@ -1,3 +1,5 @@
+@use "./mq";
+
 html {
   /**
    * Font family.
@@ -12,7 +14,11 @@ html {
    *
    * @ see https://cdn.vaadin.com/vaadin-lumo-styles/1.5.0/demo/typography.html#font-size
    */
-  --cxl-lumo-font-size-hero: 4rem;
+  --cxl-lumo-font-size-hero: var(--lumo-font-size-xxxl);
+
+  @media #{mq.$small} {
+    --cxl-lumo-font-size-hero: 4rem;
+  }
 }
 
 b,
@@ -42,15 +48,24 @@ h1 {
 }
 
 h2 {
-  font-size: var(--lumo-font-size-xxxl);
+  font-size: var(--lumo-font-size-xxl);
+  @media #{mq.$small} {
+    font-size: var(--lumo-font-size-xxxl);
+  }
 }
 
 h3 {
-  font-size: var(--lumo-font-size-xxl);
+  font-size: var(--lumo-font-size-xl);
+  @media #{mq.$small} {
+    font-size: var(--lumo-font-size-xxl);
+  }
 }
 
 h4 {
-  font-size: var(--lumo-font-size-xl);
+  font-size: var(--lumo-font-size-l);
+  @media #{mq.$small} {
+    font-size: var(--lumo-font-size-xl);
+  }
 }
 
 h5 {

--- a/packages/storybook/cxl-lumo-styles.stories.js
+++ b/packages/storybook/cxl-lumo-styles.stories.js
@@ -32,6 +32,44 @@ export const Typograhy = () => {
   `;
 };
 
+export const TypograhyUseCases = () => {
+  const loremIpsum = `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  Nam hendrerit pharetra neque, non gravida neque interdum ac.
+  Donec porttitor quis velit nec tempor. Sed arcu est, molestie ut aliquet at, egestas eu augue. Nunc lobortis imperdiet massa sed pharetra.
+  `;
+
+  return html`
+    <h1>Become great at <strong>content marketing research</strong></h1>
+    <h2>Produce relevant, authoritative content that hits money-making KPIs</h2>
+    <h3>Online Course</h3>
+    <p>By <strong>Derek Gleason</strong>, Content Lead @ CXL</p>
+    <p><strong>Course Length:</strong> 1h 07min</p>
+
+    <br />
+    <hr />
+    <h1>Digital psychology & behavioral design training</h1>
+    <p>${loremIpsum}</p>
+    <br />
+    <hr />
+    <h1>How to Design, Roll Out, & Scale an Optimization Program</h1>
+    <p>${loremIpsum}</p>
+    <br />
+    <hr />
+    <h1>Heuristic Analysis frameworks for conversion optimization audits</h1>
+    <p>${loremIpsum}</p>
+    <br />
+    <hr />
+    <h1>Implementing Urgency on eCommerce Product Pages For a 27.1% Lift [Case Study]</h1>
+    <p>${loremIpsum}</p>
+    <br />
+    <hr />
+    <h1>
+      Checkout Optimization: How Do Trust Seals Affect Security Perception? [Original Research]
+    </h1>
+    <p>${loremIpsum}</p>
+  `;
+};
+
 export const VaadinButton = () => {
   const label = text('Label', 'Button');
 


### PR DESCRIPTION
I looked into it and don't have very good news. Lumo font sizes are already relative, and it works as intended. 
In essence, this is a problem related to viewport aspect ratio in the narrow mobile screen, so It's hard to escape MQs. 

The only sane alternative that could possibly avoid media queries is using viewport relative units. But that's a nasty trap, and it comes with accessibility issues. 

I followed Martin's suggestion and used a media query close to the "menu" breakpoint. I'm not sure it's the exact one, because I used the $medium query already present in [_mq](https://github.com/conversionxl/aybolit/blob/master/packages/cxl-lumo-styles/scss/_mq.scss). 

I could not use the exact values Martin came up with. I used the closest lumo font-size presets available, for consistency. If we decide to adopt different values, I'll add new custom properties to the **html** block in [typography](https://github.com/conversionxl/aybolit/blob/master/packages/cxl-lumo-styles/scss/typography.scss).

Here are two screenshots of the new story demonstrating the change. Please use storybook's viewport settings and the "Ignore Media query" checkbox to compare new and old sizes. For viewports larger than 768px, nothing is changed. 
I also looked at other views in storybook, like **cxl-minidegree-track**, and the new font-sizes improve those too.

<img width="928" alt="Screen Shot 2020-05-19 at 23 32 23" src="https://user-images.githubusercontent.com/1887825/82399252-1d0ec580-9a2b-11ea-9634-36bb70c5a5a6.png">
<img width="928" alt="Screen Shot 2020-05-19 at 23 32 33" src="https://user-images.githubusercontent.com/1887825/82399259-20a24c80-9a2b-11ea-90b1-6fe26fc383cd.png">
