### PR TITLE
feat(cxl-ui): implemented cxl-featured-card, with [theme="cxl-testimonial"…

### DIFF
--- a/packages/cxl-ui/scss/cxl-featured-card.scss
+++ b/packages/cxl-ui/scss/cxl-featured-card.scss
@@ -1,0 +1,8 @@
+:host {
+  display: block;
+  font-family: var(--lumo-font-family);
+}
+
+:host([hidden]) {
+  display: none;
+}

--- a/packages/cxl-ui/scss/global/cxl-featured-card.scss
+++ b/packages/cxl-ui/scss/global/cxl-featured-card.scss
@@ -1,0 +1,104 @@
+cxl-featured-card {
+  box-sizing: border-box;
+  padding: var(--lumo-space-s) var(--lumo-space-m);
+  margin: var(--lumo-space-m);
+  overflow: hidden;
+  font-family: inherit;
+  text-overflow: ellipsis;
+  background: var(--lumo-base-color);
+  border: 1px solid var(--lumo-contrast-10pct);
+  border-radius: var(--lumo-border-radius);
+
+  &:hover {
+    border-color: var(--lumo-primary-color);
+  }
+
+  iron-icon {
+    --iron-icon-height: var(--lumo-icon-size-s);
+    --iron-icon-width: var(--iron-icon-height);
+  }
+
+  .card-entry-header {
+    margin: 0;
+    font-family: inherit;
+    font-style: normal;
+
+    .card-headshot {
+      width: 120px;
+      height: 120px;
+      margin: 0 auto;
+      border: 5px solid var(--lumo-base-color);
+      border-radius: 100%;
+    }
+
+    .card-company-logo {
+      max-width: 100px;
+      margin: var(--lumo-space-s) auto;
+    }
+
+    .card-name,
+    h4 {
+      padding: 0;
+      margin: 0;
+    }
+
+    .card-description,
+    p {
+      margin: 0 auto;
+      font-family: inherit;
+      font-size: var(--lumo-font-size-s);
+    }
+  }
+
+  .card-entry-summmary {
+    padding: 0 var(--lumo-space-s);
+
+    p {
+      font-family: inherit;
+    }
+  }
+
+  &[theme~="cxl-testimonial"] {
+    width: 400px;
+    min-width: 400px;
+    height: 500px;
+
+    .card-entry-header {
+      text-align: center;
+    }
+  }
+
+  &[theme~="cxl-office"] {
+    width: 350px;
+    min-width: 350px;
+    height: 350px;
+    padding: var(--lumo-space-l);
+
+    .card-entry-header {
+      text-align: left;
+
+      .card-headshot {
+        margin: 0;
+      }
+
+      .card-name,
+      h4 {
+        padding: 0;
+        margin-top: var(--lumo-space-m);
+      }
+
+      .card-description,
+      p {
+        margin-bottom: var(--lumo-space-m);
+        font-family: inherit;
+        font-size: var(--lumo-font-size-m);
+        line-height: 2;
+      }
+    }
+
+    .card-headshot {
+      width: 90px;
+      height: 90px;
+    }
+  }
+}

--- a/packages/cxl-ui/src/components/cxl-featured-card.js
+++ b/packages/cxl-ui/src/components/cxl-featured-card.js
@@ -1,0 +1,27 @@
+import { customElement, LitElement, html } from 'lit-element';
+import '@conversionxl/cxl-lumo-styles';
+import { registerGlobalStyles } from '@conversionxl/cxl-lumo-styles/src/utils';
+import cxlFeaturedCardGlobalStyles from '../styles/global/cxl-featured-card-css.js';
+import cxlFeaturedCardStyles from '../styles/cxl-featured-card-css.js';
+
+@customElement('cxl-featured-card')
+export class CXLFeaturedCard extends LitElement {
+  static get styles() {
+    return [cxlFeaturedCardStyles];
+  }
+
+  render() {
+    return html`
+      <slot></slot>
+    `;
+  }
+
+  firstUpdated(_changedProperties) {
+    super.firstUpdated(_changedProperties);
+
+    // Global styles.
+    registerGlobalStyles(cxlFeaturedCardGlobalStyles, {
+      moduleId: 'cxl-featured-card-global'
+    });
+  }
+}

--- a/packages/storybook/cxl-ui/cxl-featured-card/theme=cxl-office.stories.js
+++ b/packages/storybook/cxl-ui/cxl-featured-card/theme=cxl-office.stories.js
@@ -1,0 +1,72 @@
+import { html } from 'lit-html';
+import '@conversionxl/cxl-ui/src/components/cxl-featured-card.js';
+import '@conversionxl/cxl-lumo-styles';
+
+export default {
+  title: 'CXL UI|cxl-featured-card'
+};
+
+export const CXLOffice = () => {
+  return html`
+    <style>
+      html {
+        font-family: var(--lumo-font-family);
+      }
+
+      .entry {
+        transition: all 0.2s ease-in;
+      }
+
+      img {
+        display: block;
+      }
+
+      .offices-container {
+        font-family: var(--lumo-font-family);
+        display: flex;
+        flex-flow: row;
+        overflow-x: scroll;
+        max-width: 90%;
+        margin: 0 auto;
+      }
+
+      p,
+      blockquote {
+        margin-top: 0.5em;
+        margin-bottom: 0.75em;
+      }
+    </style>
+
+    <div class="offices-container">
+      ${Array(3)
+        .fill(
+          html`
+            <cxl-featured-card theme="cxl-office">
+              <article class="entry">
+                <header class="card-entry-header">
+                  <img
+                    class="card-headshot"
+                    src="https://cxl.com/institute/wp-content/uploads/2020/05/48192546_10156982340630746_8127333122065825792_n-wpv_400pxx400px_center_center.jpg"
+                  />
+                  <h4>Tallinn</h4>
+                  <p>Estonia</p>
+                </header>
+
+                <div class="card-entry-summary">
+                  <p>
+                    Having completed the Conversion Optimization mini degree, this has given me a
+                    perfect overall base for my current role in marketing.
+                  </p>
+                </div>
+              </article>
+            </cxl-featured-card>
+          `
+        )
+        .map(item => item)}
+    </div>
+  `;
+};
+
+CXLOffice.story = {
+  name: '[theme=cxl-office]'
+};

--- a/packages/storybook/cxl-ui/cxl-featured-card/theme=cxl-testimonial.stories.js
+++ b/packages/storybook/cxl-ui/cxl-featured-card/theme=cxl-testimonial.stories.js
@@ -1,0 +1,82 @@
+import { html } from 'lit-html';
+import '@conversionxl/cxl-ui/src/components/cxl-featured-card.js';
+import '@conversionxl/cxl-lumo-styles';
+
+export default {
+  title: 'CXL UI|cxl-featured-card'
+};
+
+export const CXLTestimonial = () => {
+  return html`
+    <style>
+      html {
+        font-family: var(--lumo-font-family);
+      }
+
+      .entry {
+        transition: all 0.2s ease-in;
+      }
+
+      img {
+        display: block;
+      }
+
+      .testimonials-container {
+        font-family: var(--lumo-font-family);
+        display: flex;
+        flex-flow: row;
+        overflow-x: scroll;
+        max-width: 90%;
+        margin: 0 auto;
+      }
+
+      p,
+      blockquote {
+        margin-top: 0.5em;
+        margin-bottom: 0.75em;
+      }
+    </style>
+
+    <div class="testimonials-container">
+      ${Array(7)
+        .fill(
+          html`
+            <cxl-featured-card theme="cxl-testimonial">
+              <article class="entry">
+                <header class="card-entry-header">
+                  <img
+                    class="card-headshot"
+                    src="https://cxl.com/institute/wp-content/uploads/2020/05/48192546_10156982340630746_8127333122065825792_n-wpv_400pxx400px_center_center.jpg"
+                  />
+                  <img
+                    class="card-company-logo"
+                    src="https://cxl.com/institute/wp-content/uploads/2020/05/Screenshot-2020-05-27-at-13.28.50.png"
+                  />
+                  <h4>Kurt S.</h4>
+                  <p>Web Conversion Manager @ Pipedrive</p>
+                  <p>Estonia</p>
+                </header>
+
+                <div class="card-entry-summary">
+                  <p>
+                    Having completed the Conversion Optimization mini degree, this has given me a
+                    perfect overall base for my current role in marketing where I’m trying to always
+                    improve the web experience.
+                  </p>
+                  <p>
+                    CXL Institute is constantly putting out new material and also updating existing
+                    material to be up to date with the current best practises.
+                  </p>
+                </div>
+              </article>
+            </cxl-featured-card>
+          `
+        )
+        .map(item => item)}
+    </div>
+  `;
+};
+
+CXLTestimonial.story = {
+  name: '[theme=cxl-testimonial]'
+};


### PR DESCRIPTION
…] and [theme="cxl-office"]

Because testimonial and office card would share almost all code, It seems to make more sense to have a generic card element with both themes. Still needs an improvement to better deal with overflowing text.
This partly matches requirements from Issue #35 

Testimonial:
<img width="1041" alt="Screen Shot 2020-06-15 at 11 30 28" src="https://user-images.githubusercontent.com/1887825/84669767-a1a21600-aefb-11ea-9d75-d9b09bcd7bf8.png">

Office:
<img width="1278" alt="Screen Shot 2020-06-15 at 11 30 58" src="https://user-images.githubusercontent.com/1887825/84669819-b1215f00-aefb-11ea-98fb-3ae92bf33f7c.png">

