### PR TITLE
feat(cxl-ui): cxl-app-layout element

### DIFF
--- a/packages/cxl-ui/scss/cxl-app-layout.scss
+++ b/packages/cxl-ui/scss/cxl-app-layout.scss
@@ -1,0 +1,180 @@
+@use "~@conversionxl/cxl-lumo-styles/scss/mixins";
+
+:host {
+  display: block;
+}
+
+#main {
+  @include mixins.wrap();
+}
+
+/**
+ * Fixed container, scrolling content columns.
+ *
+ * @see https://codepen.io/geon/pen/obrWxm
+ */
+:host([wide]) {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+
+  #main {
+    display: flex;
+    flex-grow: 1; // Short content.
+    height: 100%; // Safari.
+    overflow: hidden;
+
+    slot {
+      display: block;
+    }
+
+    > aside > slot[name="sidebar"],
+    > main {
+      height: 100%;
+      overflow-y: auto;
+      scrollbar-width: thin;
+
+      @include mixins.better-webkit-scrollbars();
+    }
+
+    > aside {
+      flex: 0 0 auto;
+    }
+
+    > main {
+      flex-grow: 1;
+    }
+  }
+}
+
+/**
+ * Drawer.
+ */
+/* stylelint-disable no-duplicate-selectors */
+$toggle-icon: "lumo:angle-right";
+
+aside {
+  --cxl-app-layout-drawer-transition: 0.25s cubic-bezier(0, 1, 0, 1);
+
+  position: relative;
+  // @see https://stackoverflow.com/questions/3508605/how-can-i-transition-height-0-to-height-auto-using-css
+  max-height: var(--lumo-font-size-xxl);
+  padding-bottom: calc(35px + var(--lumo-space-m));
+  transition: var(--cxl-app-layout-drawer-transition);
+
+  // Exclude vaadin-button.
+  ::slotted(*) {
+    opacity: 0.2;
+  }
+
+  &[opened] {
+    max-height: calc(100vh * 2);
+
+    ::slotted(*) {
+      opacity: unset;
+    }
+
+    [icon="#{$toggle-icon}"] {
+      transform: rotate(-90deg);
+    }
+  }
+
+  > vaadin-button {
+    position: absolute; // `position: sticky` retains position on scroll, but creates vertical space.
+    bottom: -1px; // Clip border.
+    z-index: 1;
+    padding: 0;
+    margin: 0;
+    background-color: var(--lumo-base-color);
+    border: solid 1px var(--lumo-contrast-10pct);
+  }
+
+  [icon="#{$toggle-icon}"] {
+    transform: rotate(90deg);
+  }
+}
+
+main {
+  position: relative; // Avoid `aside:not([opened])` bleeding through.
+  display: flow-root;
+  background-color: var(--lumo-base-color);
+  border-top: solid 1px var(--lumo-contrast-10pct);
+}
+
+:host([wide]) {
+  aside {
+    --cxl-app-layout-drawer-width: calc(22 * var(--lumo-space-m));
+    --cxl-app-layout-drawer-padding: calc(var(--cxl-wrap-padding) * 2);
+    --cxl-app-layout-drawer-peek-margin: calc(
+      -1 * (var(--cxl-app-layout-drawer-width) - var(--cxl-app-layout-drawer-padding) + 12px)
+    );
+
+    z-index: 0;
+    width: var(--cxl-app-layout-drawer-width);
+    max-height: unset;
+    padding-bottom: unset;
+    margin-right: var(--cxl-app-layout-drawer-peek-margin);
+
+    > slot[name="sidebar"] {
+      padding-right: var(--cxl-app-layout-drawer-padding);
+    }
+
+    > vaadin-button {
+      top: calc(var(--cxl-wrap-padding) - 6px);
+      bottom: unset;
+      left: 1px;
+      transition: var(--cxl-app-layout-drawer-transition);
+
+      &:hover {
+        color: var(--lumo-primary-color);
+      }
+    }
+
+    [icon="#{$toggle-icon}"] {
+      transform: unset;
+    }
+
+    &[opened] {
+      margin-right: 0;
+
+      > vaadin-button {
+        left: calc(100% + 1px);
+        transform: translateX(-100%);
+      }
+
+      [icon="#{$toggle-icon}"] {
+        transform: rotate(180deg);
+      }
+    }
+  }
+
+  main {
+    @include mixins.wrap($padding: var(--lumo-space-l));
+
+    margin-top: unset;
+
+    [icon="#{$toggle-icon}"] {
+      transform: unset;
+    }
+  }
+
+  #main {
+    // @todo #main @include mixins.wrap() shrinks flex child. Flex-native expand solution?
+    width: calc(100% - var(--cxl-wrap-padding) * 2);
+  }
+}
+/* stylelint-enable no-duplicate-selectors */
+
+/**
+ * Visuals.
+ */
+/* stylelint-disable no-duplicate-selectors */
+:host([wide]) {
+  main {
+    border-top-left-radius: var(--lumo-border-radius-l);
+    box-shadow: var(--lumo-box-shadow-s);
+  }
+}
+/* stylelint-enable no-duplicate-selectors */

--- a/packages/cxl-ui/scss/global/cxl-app-layout.scss
+++ b/packages/cxl-ui/scss/global/cxl-app-layout.scss
@@ -1,0 +1,239 @@
+@use "../mixins";
+
+cxl-app-layout {
+  /**
+   * Jobs theme
+   */
+
+  &[theme~="cxl-jobs-home"] {
+    .entry {
+      margin-top: var(--cxl-wrap-padding);
+      margin-bottom: var(--cxl-wrap-padding);
+
+      .entry-header {
+        margin: auto;
+      }
+
+      .entry-title {
+        padding-top: calc(var(--cxl-wrap-padding) * 3);
+        text-align: center;
+      }
+
+      .entry-byline {
+        text-align: center;
+      }
+    }
+
+    &[wide] {
+      --cxl-wrap-padding: var(--lumo-space-l);
+
+      .entry {
+        .entry-header,
+        .entry-content,
+        .entry-footer {
+          max-width: var(--cxl-content-width);
+          padding: 0 var(--cxl-wrap-padding);
+          margin: 0 auto;
+        }
+      }
+    }
+  }
+
+  /**
+   * Intitute theme
+   */
+  &[theme~="cxl-institute"] {
+    $iframe-height: 200px;
+
+    %label-contrast-50pct {
+      font-weight: 300;
+      color: var(--lumo-contrast-50pct);
+      text-transform: uppercase;
+    }
+
+    iframe {
+      width: 100%;
+      height: $iframe-height;
+      border: 0;
+    }
+
+    > .entry {
+      margin-top: var(--cxl-wrap-padding);
+      margin-bottom: var(--cxl-wrap-padding);
+
+      .entry-header {
+        label {
+          @extend %label-contrast-50pct;
+        }
+      }
+
+      .entry-media {
+        margin: var(--cxl-wrap-padding) calc(var(--cxl-wrap-padding) * -1); // Full screen width, while padded.
+        background-color: var(--lumo-shade);
+      }
+
+      .entry-title {
+        font-size: var(--lumo-font-size-xxxl);
+      }
+    }
+
+    > .widget {
+      margin-top: var(--cxl-wrap-padding);
+      margin-bottom: var(--cxl-wrap-padding);
+
+      .widget-title {
+        margin-top: 0;
+        font-weight: 300;
+      }
+
+      &_sensei_course_progress {
+        a {
+          color: inherit;
+        }
+
+        label {
+          @extend %label-contrast-50pct;
+        }
+
+        .entry-title {
+          @include mixins.entry-title-with-progress-icons();
+
+          font-size: var(--lumo-font-size-m);
+          font-weight: 300;
+        }
+
+        .course-progress-navigation {
+          display: flex;
+          margin-top: var(--cxl-wrap-padding);
+
+          > * {
+            flex-basis: 50%;
+          }
+
+          :first-child {
+            margin-right: var(--lumo-space-s);
+
+            /* stylelint-disable-next-line selector-max-compound-selectors */
+            + :last-child {
+              margin-left: var(--lumo-space-s);
+            }
+          }
+        }
+
+        .current-menu-item {
+          .entry-title {
+            font-weight: 700;
+            text-decoration: underline;
+          }
+        }
+      }
+    }
+
+    &[wide] {
+      --cxl-wrap-padding: var(--lumo-space-l);
+
+      iframe {
+        height: $iframe-height * 2;
+      }
+
+      > .entry {
+        .entry-content,
+        .entry-footer {
+          max-width: var(--cxl-content-width);
+          padding: 0 var(--cxl-wrap-padding);
+          margin: 0 auto;
+        }
+      }
+    }
+  }
+
+  /**
+   * Flipped layout.
+   * Padding is affected by scrollbar positions.
+   */
+  /* stylelint-disable selector-max-type */
+  /* stylelint-disable selector-max-attribute */
+
+  &[theme~="2c-l"] {
+    #main {
+      display: flex;
+      flex-direction: column;
+    }
+  }
+
+  /**
+   * No reason to hide anything when at screen bottom.
+   */
+  &[theme~="2c-l"]:not([wide]) {
+    aside {
+      max-height: unset;
+      padding-bottom: unset;
+
+      > vaadin-button {
+        display: none;
+      }
+
+      ::slotted(*) {
+        opacity: unset;
+      }
+    }
+  }
+
+  &[theme~="2c-l"][wide] {
+    aside {
+      margin-right: calc(
+        var(--cxl-app-layout-drawer-peek-margin) + var(--cxl-app-layout-drawer-padding)
+      );
+
+      > slot[name="sidebar"] {
+        padding-left: var(--cxl-app-layout-drawer-padding);
+      }
+
+      > vaadin-button {
+        left: -1px;
+      }
+
+      .aside-toggle-button [icon] {
+        transform: rotate(180deg);
+      }
+
+      // Better closed drawer fade.
+      &::after {
+        position: absolute;
+        top: 0;
+        left: var(--cxl-app-layout-drawer-padding);
+        display: block;
+        width: var(--cxl-app-layout-drawer-padding);
+        height: 100%;
+        content: "";
+        background: linear-gradient(to right, rgba(255, 255, 255, 0), var(--lumo-base-color));
+      }
+
+      &[opened] {
+        margin-right: 0;
+
+        > vaadin-button {
+          transform: unset;
+        }
+
+        .aside-toggle-button [icon] {
+          transform: unset;
+        }
+
+        &::after {
+          content: unset;
+        }
+      }
+    }
+
+    #main {
+      flex-direction: unset;
+
+      // Stop padding-box overflow leak.
+      padding-right: unset;
+      border-right: solid var(--cxl-wrap-padding) transparent;
+    }
+  }
+}
+/* stylelint-enable selector-max-type */
+/* stylelint-enable selector-max-attribute */

--- a/packages/cxl-ui/src/components/cxl-app-layout.js
+++ b/packages/cxl-ui/src/components/cxl-app-layout.js
@@ -1,0 +1,149 @@
+/**
+ * @todo implement primary action button.
+ */
+import { LitElement, html, customElement, property, query } from 'lit-element';
+import '@conversionxl/cxl-lumo-styles';
+import { registerGlobalStyles } from '@conversionxl/cxl-lumo-styles/src/utils';
+import cxlAppLayoutStyles from '../styles/cxl-app-layout-css.js';
+import cxlAppLayoutGlobalStyles from '../styles/global/cxl-app-layout-css.js';
+import '@vaadin/vaadin-button';
+import '@vaadin/vaadin-context-menu/src/vaadin-device-detector.js';
+import '@vaadin/vaadin-tabs';
+import '@vaadin/vaadin-progress-bar';
+
+@customElement('cxl-app-layout')
+export class CXLAppLayout extends LitElement {
+  @query('aside')
+  asideElement;
+
+  @property({ type: String, attribute: 'aside-local-storage-key' })
+  _asideLocalStorageKey = `cxl-app-layout-aside-opened--${window.location.pathname}`;
+
+  @property({ type: Boolean })
+  get asideOpened() {
+    this._asideOpened = JSON.parse(localStorage.getItem(this._asideLocalStorageKey));
+
+    return this._asideOpened === null || this._asideOpened;
+  }
+
+  set asideOpened(value) {
+    localStorage.setItem(this._asideLocalStorageKey, JSON.stringify(value));
+
+    this.requestUpdate('asideOpened', this._asideOpened);
+  }
+
+  // vaadin-device-detector.
+  @property({ type: Boolean, reflect: true })
+  wide;
+
+  @property({ type: Boolean, attribute: false })
+  _twoColumn;
+
+  @property({ type: Boolean, attribute: false })
+  _rightSideMain;
+
+  @property({ type: String })
+  get theme() {
+    return this._theme;
+  }
+
+  set theme(value) {
+    if (typeof value !== 'string') return;
+    switch (value) {
+      case '2c-l':
+        this._twoColumn = true;
+        this._rightSideMain = true;
+        break;
+      case 'cxl-institute':
+        this._twoColumn = true;
+        this._rightSideMain = false;
+        break;
+      default:
+        this._twoColumn = false;
+        break;
+    }
+    this._theme = value;
+  }
+
+  static get styles() {
+    return [cxlAppLayoutStyles];
+  }
+
+  render() {
+    const asideElement = html`
+      <aside
+        role="complementary"
+        aria-label="Primary sidebar"
+        itemscope="itemscope"
+        itemtype="https://schema.org/WPSideBar"
+        ?opened="${this.asideOpened}"
+      >
+        <vaadin-button
+          aria-label="Toggle sidebar"
+          class="aside-toggle-button"
+          theme="contrast icon"
+          @click="${() => {
+            this.asideOpened = !this.asideOpened;
+          }}"
+        >
+          <iron-icon icon="lumo:angle-right"></iron-icon>
+        </vaadin-button>
+        <slot name="sidebar"></slot>
+      </aside>
+    `;
+
+    const mainElement = html`
+      <main role="main" itemprop="mainContentOfPage">
+        <slot></slot>
+      </main>
+    `;
+
+    return html`
+      <header role="banner" itemscope="itemscope" itemtype="https://schema.org/WPHeader">
+        <slot name="header"></slot>
+      </header>
+
+      <div id="main">
+        ${this._renderMainComponents(mainElement, asideElement)}
+      </div>
+
+      <footer role="contentinfo" itemscope="itemscope" itemtype="https://schema.org/WPFooter">
+        <slot name="footer"></slot>
+      </footer>
+
+      <vaadin-device-detector
+        @wide-changed="${e => {
+          const { wide } = e.target;
+
+          Promise.resolve().then(() => {
+            this.wide = wide;
+          });
+        }}"
+      ></vaadin-device-detector>
+    `;
+  }
+
+  _renderMainComponents(mainElement, asideElement) {
+    if (!this._twoColumn)
+      return html`
+        ${mainElement}
+      `;
+
+    return this._rightSideMain
+      ? html`
+          ${asideElement} ${mainElement}
+        `
+      : html`
+          ${mainElement} ${asideElement}
+        `;
+  }
+
+  firstUpdated(_changedProperties) {
+    super.firstUpdated(_changedProperties);
+
+    // Global styles.
+    registerGlobalStyles(cxlAppLayoutGlobalStyles, {
+      moduleId: 'cxl-app-layout-global'
+    });
+  }
+}


### PR DESCRIPTION
This is `cxl-institute-layout` compatible, which means it can replace that element without any changes to the content.
It makes it possible to have a simple layout with the `aside` element hidden. It's also ground work for jobs layout and #47 