### PR TITLE
style(cxl-lumo-styles): vaadin-tabs[theme=cxl-horizontal-slider]

### DIFF
--- a/packages/cxl-lumo-styles/scss/themes/vaadin-tabs.scss
+++ b/packages/cxl-lumo-styles/scss/themes/vaadin-tabs.scss
@@ -65,3 +65,43 @@ $vaadin-tab-horizontal-padding: 0.75rem;
   margin-right: auto;
   margin-left: auto;
 }
+
+// show horizontal scrollbar
+// needs to refactor, so utilize custom css properties
+:host([orientation="horizontal"][theme~="cxl-jobs-horizontal-slider"]) [part="tabs"] {
+  // override default vaadin-tabs overflow
+  overflow-x: auto;
+
+  &::-webkit-scrollbar {
+    // override default vaadin-tabs scrollbar display
+    display: initial;
+
+    width: 2px;
+    height: 8px;
+  }
+
+  &::-webkit-scrollbar-button {
+    width: 0;
+    height: 0;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: #d61f2c;
+    border: 0 none #fff;
+    border-radius: 50px;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: #d61f2c;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: #f5f5f5;
+    border: 0 none #fff;
+    border-radius: 50px;
+  }
+
+  &::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+}

--- a/packages/storybook/cxl-ui/cxl-jobs-components/vaadin-tabs[theme=cxl-jobs-horizontal-slider].stories.js
+++ b/packages/storybook/cxl-ui/cxl-jobs-components/vaadin-tabs[theme=cxl-jobs-horizontal-slider].stories.js
@@ -1,0 +1,53 @@
+import '@conversionxl/cxl-lumo-styles';
+import { html } from 'lit-html';
+
+export default {
+  title: 'CXL UI|cxl-jobs-components'
+};
+
+export const VaadinButton = () => {
+  return html`
+    <vaadin-tabs orientation="horizontal" theme="cxl-jobs-horizontal-slider minimal">
+      <vaadin-tab>
+        <figure>
+          <img
+            src="http://jobs.uprecords.org/wp-content/uploads/sites/4/2020/01/slide-img-1.jpg"
+            alt=""
+            data-id="220"
+            data-full-url="http://jobs.uprecords.org/wp-content/uploads/sites/4/2020/01/slide-img-1.jpg"
+            data-link="http://jobs.uprecords.org/sample-page/slide-img-1-2/"
+            class="wp-image-220"
+          />
+        </figure>
+      </vaadin-tab>
+      <vaadin-tab>
+        <figure>
+          <img
+            src="http://jobs.uprecords.org/wp-content/uploads/sites/4/2020/01/slide-img-2.jpg"
+            alt=""
+            data-id="221"
+            data-full-url="http://jobs.uprecords.org/wp-content/uploads/sites/4/2020/01/slide-img-2.jpg"
+            data-link="http://jobs.uprecords.org/sample-page/slide-img-2/"
+            class="wp-image-221"
+          />
+        </figure>
+      </vaadin-tab>
+      <vaadin-tab>
+        <figure>
+          <img
+            src="http://jobs.uprecords.org/wp-content/uploads/sites/4/2020/01/slide-img-3.jpg"
+            alt=""
+            data-id="222"
+            data-full-url="http://jobs.uprecords.org/wp-content/uploads/sites/4/2020/01/slide-img-3.jpg"
+            data-link="http://jobs.uprecords.org/sample-page/slide-img-3-2/"
+            class="wp-image-222"
+          />
+        </figure>
+      </vaadin-tab>
+    </vaadin-tabs>
+  `;
+};
+
+VaadinButton.story = {
+  name: 'vaadin-tabs[theme=cxl-jobs-horizontal-slider]'
+};


### PR DESCRIPTION
This adds a theme to vaadin-tabs, so it can be used as a horizontal scrolling gallery, without hiding the scrollbar. Includes
Syed's refactor.