### PR TITLE
feat: create hubs page draft for initial check, introduce masonry layout webcomponent

### DIFF
--- a/packages/cxl-ui/package.json
+++ b/packages/cxl-ui/package.json
@@ -10,6 +10,7 @@
     "directory": "packages/cxl-ui"
   },
   "dependencies": {
+    "@appnest/masonry-layout": "^2.0.8",
     "@conversionxl/cxl-lumo-styles": "^0.2.2",
     "@pika/pack": "^0.5.0",
     "@pika/plugin-build-web": "^0.9.2",

--- a/packages/cxl-ui/scss/global/cxl-vaadin-accordion.scss
+++ b/packages/cxl-ui/scss/global/cxl-vaadin-accordion.scss
@@ -134,4 +134,128 @@ cxl-vaadin-accordion {
       background-color: var(--lumo-contrast-70pct);
     }
   }
+
+  // Greg: these will probably get removed but i needed to add them somewhere
+
+  &[theme~="cxl-hub-cards"] {
+    @media #{mq.$large} {
+      column-count: 2;
+      column-gap: calc(var(--lumo-space-m) * 2);
+    }
+
+    iron-icon {
+      --iron-icon-height: var(--lumo-icon-size-s);
+      --iron-icon-width: var(--iron-icon-height);
+    }
+
+    p {
+      font-family: inherit;
+    }
+
+    .entry-byline {
+      display: flex; // iron-icon vs text alignment
+      flex-basis: 100%;
+      flex-wrap: wrap;
+      margin: var(--lumo-space-s) 0;
+      overflow: hidden;
+      font-weight: 300;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+
+      // @see https://stackoverflow.com/questions/29732575/how-to-specify-line-breaks-in-a-multi-line-flexbox-layout
+      hr {
+        width: 100%;
+        margin: 0;
+        visibility: hidden;
+      }
+    }
+
+    .entry-title {
+      flex: 1;
+      height: auto;
+      overflow: hidden;
+      font-size: var(--lumo-font-size-xl);
+      word-break: break-word;
+
+      a {
+        display: block;
+        margin-top: var(--lumo-space-m);
+        margin-bottom: var(--lumo-space-m);
+        font-size: var(--lumo-font-size-xl);
+        line-height: var(--lumo-line-height-s);
+        color: inherit;
+      }
+
+      .super-title {
+        font-size: var(--lumo-font-size-m);
+        color: var(--lumo-secondary-text-color);
+      }
+    }
+
+    .thumbnail {
+      --cxl-thumbnail-size: 64px;
+      background-color: var(--lumo-contrast-70pct);
+    }
+
+    .entry-breadcrumbs-list {
+      padding-left: 0;
+      margin-left: 0;
+      list-style-type: none;
+    }
+
+    .entry-breacdrumbs-list-element {
+      display: inline;
+      a {
+        color: var(--lumo-secondary-text-color);
+      }
+      &::after {
+        color: var(--lumo-secondary-text-color);
+        content: "/";
+      }
+    }
+
+    .entry-breacdrumbs-list-element:last-child {
+      &::after {
+        display: none;
+        content: "";
+      }
+    }
+
+    // This one fixes layout when there's no image on the right because of ::slotted flex-wrap : [
+    cxl-accordion-card {
+      .entry-header {
+        display: block;
+      }
+    }
+
+    cxl-accordion-card[theme~="light"] {
+      // &[opened] {
+      //   border-bottom: 1px solid var(--lumo-primary-color);
+      // }
+
+      &:hover {
+        border-bottom: 1px solid var(--lumo-primary-color);
+      }
+
+      // Dirty? Not sure why needed, but needed - Greg, otherwise the bottom border style gets lost somewhere, but if we only
+      // add the style to the bottom when opened & hovered, the things will be jumping across the columns yuck
+      border-bottom: 1px solid transparent;
+
+      // &[opened], &:hover {
+      //   border-bottom: 1px solid var(--lumo-primary-color);
+      // }
+
+      .entry-title {
+        .super-title {
+          color: var(--lumo-primary-text-color);
+        }
+      }
+    }
+
+    cxl-accordion-card[opened] {
+      .entry-title {
+        overflow: visible;
+      }
+    }
+  }
 }

--- a/packages/cxl-ui/scss/global/cxl-vaadin-accordion.scss
+++ b/packages/cxl-ui/scss/global/cxl-vaadin-accordion.scss
@@ -229,10 +229,6 @@ cxl-vaadin-accordion {
     }
 
     cxl-accordion-card[theme~="light"] {
-      // &[opened] {
-      //   border-bottom: 1px solid var(--lumo-primary-color);
-      // }
-
       &:hover {
         border-bottom: 1px solid var(--lumo-primary-color);
       }
@@ -253,6 +249,7 @@ cxl-vaadin-accordion {
     }
 
     cxl-accordion-card[opened] {
+      border-bottom: 1px solid var(--lumo-primary-color);
       .entry-title {
         overflow: visible;
       }

--- a/packages/cxl-ui/scss/global/cxl-vaadin-accordion.scss
+++ b/packages/cxl-ui/scss/global/cxl-vaadin-accordion.scss
@@ -139,8 +139,19 @@ cxl-vaadin-accordion {
 
   &[theme~="cxl-hub-cards"] {
     @media #{mq.$large} {
-      column-count: 2;
-      column-gap: calc(var(--lumo-space-m) * 2);
+      // column-count: 2;
+      // column-gap: calc(var(--lumo-space-m) * 2);
+
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      grid-template-rows: 1fr;
+      gap: var(--lumo-space-m) var(--lumo-space-m);
+      grid-template-areas: ". .";
+
+      // display: flex;
+      // flex-direction: row;
+      // flex-wrap: wrap;
+      // width: 100%;
     }
 
     iron-icon {
@@ -223,6 +234,16 @@ cxl-vaadin-accordion {
 
     // This one fixes layout when there's no image on the right because of ::slotted flex-wrap : [
     cxl-accordion-card {
+      height: min-content;
+      margin: 0;
+
+      // Super dirty Greg!
+
+      // display: flex;
+      // flex-direction: column;
+      // flex-basis: 100%;
+      // flex: 1;
+
       .entry-header {
         display: block;
       }

--- a/packages/cxl-ui/scss/global/cxl-vaadin-accordion.scss
+++ b/packages/cxl-ui/scss/global/cxl-vaadin-accordion.scss
@@ -139,14 +139,18 @@ cxl-vaadin-accordion {
 
   &[theme~="cxl-hub-cards"] {
     @media #{mq.$large} {
+
+      // Greg: tried these three approaches, including the original column-approach
+      // but the design suggests the 'masonry' layout very strongly so went this way
+
       // column-count: 2;
       // column-gap: calc(var(--lumo-space-m) * 2);
 
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      grid-template-rows: 1fr;
-      gap: var(--lumo-space-m) var(--lumo-space-m);
-      grid-template-areas: ". .";
+      // display: grid;
+      // grid-template-columns: 1fr 1fr;
+      // grid-template-rows: 1fr;
+      // gap: var(--lumo-space-m) var(--lumo-space-m);
+      // grid-template-areas: ". .";
 
       // display: flex;
       // flex-direction: row;
@@ -187,6 +191,7 @@ cxl-vaadin-accordion {
       overflow: hidden;
       font-size: var(--lumo-font-size-xl);
       word-break: break-word;
+      margin: 0;
 
       a {
         display: block;
@@ -235,15 +240,7 @@ cxl-vaadin-accordion {
     // This one fixes layout when there's no image on the right because of ::slotted flex-wrap : [
     cxl-accordion-card {
       height: min-content;
-      margin: 0;
-
-      // Super dirty Greg!
-
-      // display: flex;
-      // flex-direction: column;
-      // flex-basis: 100%;
-      // flex: 1;
-
+      margin: 0 0 var(--lumo-space-m) 0;
       .entry-header {
         display: block;
       }
@@ -271,9 +268,9 @@ cxl-vaadin-accordion {
 
     cxl-accordion-card[opened] {
       border-bottom: 1px solid var(--lumo-primary-color);
-      .entry-title {
-        overflow: visible;
-      }
+      // .entry-title {
+      //   overflow: visible;
+      // }
     }
   }
 }

--- a/packages/storybook/cxl-hubpage/cxl-hubpage-render-hubs.js
+++ b/packages/storybook/cxl-hubpage/cxl-hubpage-render-hubs.js
@@ -1,0 +1,62 @@
+import { html } from 'lit-html';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html';
+import hubsData from './cxl-hubpage.hubs.data.json';
+import '@conversionxl/cxl-ui/src/components/cxl-accordion-card.js';
+
+const RenderHubs = () =>
+  hubsData.map(
+    (el) => html`<cxl-accordion-card
+      id="${el.cxl_hybrid_attr_post['@attributes'].id}"
+      class="${el.cxl_hybrid_attr_post['@attributes'].class}"
+      theme="dark"
+    >
+      <header class="entry-header" slot="summary">
+        <h3 class="entry-title no-anchor" itemprop="headline">
+          <div class="super-title">Playbook Hub</div>
+          <a href="${el.conversionxl_certificate_sales_page}" rel="bookmark" itemprop="url"
+            >${el.title.raw}</a
+          >
+        </h3>
+
+        <!-- DISABLE SHOWING IMAGES as per design request -->
+        <!-- <a href="{el.conversionxl_certificate_sales_page}" rel="bookmark" itemprop="url">
+            <img
+              class="landscape cw-greater thumbnail shop_catalog lazyloaded"
+              alt="{el.title.raw}"
+              itemprop="image"
+              src="{el.cxl_featured_media.shop_catalog}"
+              data-src="{el.cxl_featured_media.shop_catalog}"
+              loading="lazy"
+              width="150"
+              height="150"
+            />
+          </a> -->
+
+        <div class="entry-byline">
+          ${el.cxl_subhubs_count} Hubs, ${el.cxl_playbooks_count} Playbooks
+          <hr />
+          ${el.cxl_section_owner ? html`Section owner: ${el.cxl_section_owner}` : ''}
+        </div>
+      </header>
+
+      <div class="entry-summary" itemprop="description">
+        ${unsafeHTML(el.content.cxl_get_extended_main)}
+        <ul class="entry-breadcrumbs-list">
+          ${el.cxl_breadcrumbs
+            .slice(0, 3)
+            .map(
+              (breadcrumb) =>
+                html`<li class="entry-breacdrumbs-list-element"><a href="#">${breadcrumb}</a></li>`
+            )}
+        </ul>
+      </div>
+
+      <div class="entry-footer" style="text-align: right;">
+        <a href="${el.conversionxl_certificate_sales_page}"
+          >Open<iron-icon icon="lumo:angle-right"></iron-icon
+        ></a>
+      </div>
+    </cxl-accordion-card>`
+  );
+
+export default RenderHubs;

--- a/packages/storybook/cxl-hubpage/cxl-hubpage-render-playbooks.js
+++ b/packages/storybook/cxl-hubpage/cxl-hubpage-render-playbooks.js
@@ -1,0 +1,62 @@
+import { html } from 'lit-html';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html';
+import playbooksData from './cxl-hubpage.playbooks.data.json';
+import '@conversionxl/cxl-ui/src/components/cxl-accordion-card.js';
+
+const RenderPlaybooks = () =>
+  playbooksData.map(
+    (el) => html`<cxl-accordion-card
+      id="${el.cxl_hybrid_attr_post['@attributes'].id}"
+      class="${el.cxl_hybrid_attr_post['@attributes'].class}"
+      theme="light"
+    >
+      <header class="entry-header" slot="summary">
+        <h3 class="entry-title no-anchor" itemprop="headline">
+          <div class="super-title">Playbook</div>
+          <a href="${el.conversionxl_certificate_sales_page}" rel="bookmark" itemprop="url"
+            >${el.title.raw}</a
+          >
+        </h3>
+
+        <!-- DISABLE SHOWING IMAGES as per design request -->
+        <!-- <a href="{el.conversionxl_certificate_sales_page}" rel="bookmark" itemprop="url">
+            <img
+              class="landscape cw-greater thumbnail shop_catalog lazyloaded"
+              alt="{el.title.raw}"
+              itemprop="image"
+              src="{el.cxl_featured_media.shop_catalog}"
+              data-src="{el.cxl_featured_media.shop_catalog}"
+              loading="lazy"
+              width="150"
+              height="150"
+            />
+          </a> -->
+
+        <div class="entry-byline">
+          ${el.cxl_steps_count} Steps
+          <hr />
+          ${el.cxl_author ? html`Author: ${el.cxl_author}` : ''}
+        </div>
+      </header>
+
+      <div class="entry-summary" itemprop="description">
+        ${unsafeHTML(el.content.cxl_get_extended_main)}
+        <ul class="entry-breadcrumbs-list">
+          ${el.cxl_breadcrumbs
+            .slice(0, 3)
+            .map(
+              (breadcrumb) =>
+                html`<li class="entry-breacdrumbs-list-element"><a href="#">${breadcrumb}</a></li>`
+            )}
+        </ul>
+      </div>
+
+      <div class="entry-footer" style="text-align: right;">
+        <a href="${el.conversionxl_certificate_sales_page}"
+          >Open<iron-icon icon="lumo:angle-right"></iron-icon
+        ></a>
+      </div>
+    </cxl-accordion-card>`
+  );
+
+export default RenderPlaybooks;

--- a/packages/storybook/cxl-hubpage/cxl-hubpage.hubs.data.json
+++ b/packages/storybook/cxl-hubpage/cxl-hubpage.hubs.data.json
@@ -1,0 +1,126 @@
+[
+  {
+    "id": 442534,
+    "title": {
+      "raw": "Do conversion A\/B testing"
+    },
+    "content": {
+      "cxl_get_extended_main": "<p>This is an example description of a Hub. Below are the breacrumbs that are taken directly from the fake JSON definition.<\/p>"
+    },
+    "featured_media": 1497178,
+    "categories": [
+      562
+    ],
+    "cxl_item_type": "hub",
+    "cxl_breadcrumbs": ["breadcrumbs", "only", "three", "of", "five"],
+    "cxl_subhubs_count": 2,
+    "cxl_playbooks_count": 10,
+    "cxl_section_owner": "Mr Testing",
+    "conversionxl_certificate_sales_page": "https:\/\/cxl.com\/institute\/online-course\/ab-testing-mastery\/",
+    "conversionxl_live_course_duration": "8h",
+    "cxl_hybrid_attr_post": {
+      "@attributes": {
+        "class": "entry author-maddie-sidoff-3 has-more-link post-442534 certificate type-certificate status-publish has-post-thumbnail category-online-trainings membership-content access-granted format-previously live column pure-u-1 pure-u-sm-1-2 pure-u-lg-1-3",
+        "itemscope": "itemscope",
+        "itemtype": "http:\/\/schema.org\/CreativeWork",
+        "id": "post-442534"
+      }
+    },
+    "cxl_featured_media": {
+      "shop_catalog": "https:\/\/cxl.com\/institute\/wp-content\/uploads\/2017\/12\/ton-wesseling-1x1-bw-transparent-150x150.png"
+    }
+  },
+  {
+    "id": 442534,
+    "title": {
+      "raw": "Another title here one two"
+    },
+    "content": {
+      "cxl_get_extended_main": "<p>This is an example description of a Hub. Below are the breacrumbs that are taken directly from the fake JSON definition.<\/p>"
+    },
+    "featured_media": 1497178,
+    "categories": [
+      562
+    ],
+    "cxl_item_type": "hub",
+    "cxl_breadcrumbs": ["breadcrumbs", "only", "three", "of", "five"],
+    "cxl_subhubs_count": 2,
+    "cxl_playbooks_count": 10,
+    "cxl_section_owner": "Mr Somebody Else",
+    "conversionxl_certificate_sales_page": "https:\/\/cxl.com\/institute\/online-course\/ab-testing-mastery\/",
+    "conversionxl_live_course_duration": "8h",
+    "cxl_hybrid_attr_post": {
+      "@attributes": {
+        "class": "entry author-maddie-sidoff-3 has-more-link post-442534 certificate type-certificate status-publish has-post-thumbnail category-online-trainings membership-content access-granted format-previously live column pure-u-1 pure-u-sm-1-2 pure-u-lg-1-3",
+        "itemscope": "itemscope",
+        "itemtype": "http:\/\/schema.org\/CreativeWork",
+        "id": "post-442534"
+      }
+    },
+    "cxl_featured_media": {
+      "shop_catalog": "https:\/\/cxl.com\/institute\/wp-content\/uploads\/2017\/12\/ton-wesseling-1x1-bw-transparent-150x150.png"
+    }
+  },
+  {
+    "id": 442534,
+    "title": {
+      "raw": "Test title here one two three"
+    },
+    "content": {
+      "cxl_get_extended_main": "<p>This is an example description of a Hub. Below are the breacrumbs that are taken directly from the fake JSON definition.<\/p>"
+    },
+    "featured_media": 1497178,
+    "categories": [
+      562
+    ],
+    "cxl_item_type": "hub",
+    "cxl_breadcrumbs": ["breadcrumbs", "only", "three", "of", "five"],
+    "cxl_subhubs_count": 2,
+    "cxl_playbooks_count": 10,
+    "cxl_section_owner": "Mr Testing",
+    "conversionxl_certificate_sales_page": "https:\/\/cxl.com\/institute\/online-course\/ab-testing-mastery\/",
+    "conversionxl_live_course_duration": "8h",
+    "cxl_hybrid_attr_post": {
+      "@attributes": {
+        "class": "entry author-maddie-sidoff-3 has-more-link post-442534 certificate type-certificate status-publish has-post-thumbnail category-online-trainings membership-content access-granted format-previously live column pure-u-1 pure-u-sm-1-2 pure-u-lg-1-3",
+        "itemscope": "itemscope",
+        "itemtype": "http:\/\/schema.org\/CreativeWork",
+        "id": "post-442534"
+      }
+    },
+    "cxl_featured_media": {
+      "shop_catalog": "https:\/\/cxl.com\/institute\/wp-content\/uploads\/2017\/12\/ton-wesseling-1x1-bw-transparent-150x150.png"
+    }
+  },
+  {
+    "id": 442534,
+    "title": {
+      "raw": "Lorem ipsum title four five"
+    },
+    "content": {
+      "cxl_get_extended_main": "<p>This is an example description of a Hub. Below are the breacrumbs that are taken directly from the fake JSON definition.<\/p>"
+    },
+    "featured_media": 1497178,
+    "categories": [
+      562
+    ],
+    "cxl_item_type": "hub",
+    "cxl_breadcrumbs": ["breadcrumbs", "only", "three", "of", "five"],
+    "cxl_subhubs_count": 2,
+    "cxl_playbooks_count": 10,
+    "cxl_section_owner": "Mr Testing",
+    "conversionxl_certificate_sales_page": "https:\/\/cxl.com\/institute\/online-course\/ab-testing-mastery\/",
+    "conversionxl_live_course_duration": "8h",
+    "cxl_hybrid_attr_post": {
+      "@attributes": {
+        "class": "entry author-maddie-sidoff-3 has-more-link post-442534 certificate type-certificate status-publish has-post-thumbnail category-online-trainings membership-content access-granted format-previously live column pure-u-1 pure-u-sm-1-2 pure-u-lg-1-3",
+        "itemscope": "itemscope",
+        "itemtype": "http:\/\/schema.org\/CreativeWork",
+        "id": "post-442534"
+      }
+    },
+    "cxl_featured_media": {
+      "shop_catalog": "https:\/\/cxl.com\/institute\/wp-content\/uploads\/2017\/12\/ton-wesseling-1x1-bw-transparent-150x150.png"
+    }
+  }
+]

--- a/packages/storybook/cxl-hubpage/cxl-hubpage.playbooks.data.json
+++ b/packages/storybook/cxl-hubpage/cxl-hubpage.playbooks.data.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": 442534,
+    "title": {
+      "raw": "Do conversion A\/B testing"
+    },
+    "content": {
+      "cxl_get_extended_main": "<p>This is an example description of a Playboom. Below are the breacrumbs that are taken directly from the fake JSON definition.<\/p>"
+    },
+    "featured_media": 1497178,
+    "categories": [
+      562
+    ],
+    "cxl_item_type": "hub",
+    "cxl_breadcrumbs": ["breadcrumbs", "only", "three", "of", "five"],
+    "cxl_steps_count": 10,
+    "cxl_author": "Mr Author",
+    "conversionxl_certificate_sales_page": "https:\/\/cxl.com\/institute\/online-course\/ab-testing-mastery\/",
+    "conversionxl_live_course_duration": "8h",
+    "cxl_hybrid_attr_post": {
+      "@attributes": {
+        "class": "entry author-maddie-sidoff-3 has-more-link post-442534 certificate type-certificate status-publish has-post-thumbnail category-online-trainings membership-content access-granted format-previously live column pure-u-1 pure-u-sm-1-2 pure-u-lg-1-3",
+        "itemscope": "itemscope",
+        "itemtype": "http:\/\/schema.org\/CreativeWork",
+        "id": "post-442534"
+      }
+    },
+    "cxl_featured_media": {
+      "shop_catalog": "https:\/\/cxl.com\/institute\/wp-content\/uploads\/2017\/12\/ton-wesseling-1x1-bw-transparent-150x150.png"
+    }
+  }
+]

--- a/packages/storybook/cxl-hubpage/cxl-hubpage.playbooks.data.json
+++ b/packages/storybook/cxl-hubpage/cxl-hubpage.playbooks.data.json
@@ -28,5 +28,125 @@
     "cxl_featured_media": {
       "shop_catalog": "https:\/\/cxl.com\/institute\/wp-content\/uploads\/2017\/12\/ton-wesseling-1x1-bw-transparent-150x150.png"
     }
+  },
+  {
+    "id": 442534,
+    "title": {
+      "raw": "Do conversion A\/B testing"
+    },
+    "content": {
+      "cxl_get_extended_main": "<p>This is an example description of a Playboom. Below are the breacrumbs that are taken directly from the fake JSON definition.<\/p>"
+    },
+    "featured_media": 1497178,
+    "categories": [
+      562
+    ],
+    "cxl_item_type": "hub",
+    "cxl_breadcrumbs": ["breadcrumbs", "only", "three", "of", "five"],
+    "cxl_steps_count": 10,
+    "cxl_author": "Mr Author",
+    "conversionxl_certificate_sales_page": "https:\/\/cxl.com\/institute\/online-course\/ab-testing-mastery\/",
+    "conversionxl_live_course_duration": "8h",
+    "cxl_hybrid_attr_post": {
+      "@attributes": {
+        "class": "entry author-maddie-sidoff-3 has-more-link post-442534 certificate type-certificate status-publish has-post-thumbnail category-online-trainings membership-content access-granted format-previously live column pure-u-1 pure-u-sm-1-2 pure-u-lg-1-3",
+        "itemscope": "itemscope",
+        "itemtype": "http:\/\/schema.org\/CreativeWork",
+        "id": "post-442534"
+      }
+    },
+    "cxl_featured_media": {
+      "shop_catalog": "https:\/\/cxl.com\/institute\/wp-content\/uploads\/2017\/12\/ton-wesseling-1x1-bw-transparent-150x150.png"
+    }
+  },
+  {
+    "id": 442534,
+    "title": {
+      "raw": "Do conversion A\/B testing"
+    },
+    "content": {
+      "cxl_get_extended_main": "<p>This is an example description of a Playboom. Below are the breacrumbs that are taken directly from the fake JSON definition.<\/p>"
+    },
+    "featured_media": 1497178,
+    "categories": [
+      562
+    ],
+    "cxl_item_type": "hub",
+    "cxl_breadcrumbs": ["breadcrumbs", "only", "three", "of", "five"],
+    "cxl_steps_count": 10,
+    "cxl_author": "Mr Author",
+    "conversionxl_certificate_sales_page": "https:\/\/cxl.com\/institute\/online-course\/ab-testing-mastery\/",
+    "conversionxl_live_course_duration": "8h",
+    "cxl_hybrid_attr_post": {
+      "@attributes": {
+        "class": "entry author-maddie-sidoff-3 has-more-link post-442534 certificate type-certificate status-publish has-post-thumbnail category-online-trainings membership-content access-granted format-previously live column pure-u-1 pure-u-sm-1-2 pure-u-lg-1-3",
+        "itemscope": "itemscope",
+        "itemtype": "http:\/\/schema.org\/CreativeWork",
+        "id": "post-442534"
+      }
+    },
+    "cxl_featured_media": {
+      "shop_catalog": "https:\/\/cxl.com\/institute\/wp-content\/uploads\/2017\/12\/ton-wesseling-1x1-bw-transparent-150x150.png"
+    }
+  },
+  {
+    "id": 442534,
+    "title": {
+      "raw": "Do conversion A\/B testing"
+    },
+    "content": {
+      "cxl_get_extended_main": "<p>This is an example description of a Playboom. Below are the breacrumbs that are taken directly from the fake JSON definition.<\/p>"
+    },
+    "featured_media": 1497178,
+    "categories": [
+      562
+    ],
+    "cxl_item_type": "hub",
+    "cxl_breadcrumbs": ["breadcrumbs", "only", "three", "of", "five"],
+    "cxl_steps_count": 10,
+    "cxl_author": "Mr Author",
+    "conversionxl_certificate_sales_page": "https:\/\/cxl.com\/institute\/online-course\/ab-testing-mastery\/",
+    "conversionxl_live_course_duration": "8h",
+    "cxl_hybrid_attr_post": {
+      "@attributes": {
+        "class": "entry author-maddie-sidoff-3 has-more-link post-442534 certificate type-certificate status-publish has-post-thumbnail category-online-trainings membership-content access-granted format-previously live column pure-u-1 pure-u-sm-1-2 pure-u-lg-1-3",
+        "itemscope": "itemscope",
+        "itemtype": "http:\/\/schema.org\/CreativeWork",
+        "id": "post-442534"
+      }
+    },
+    "cxl_featured_media": {
+      "shop_catalog": "https:\/\/cxl.com\/institute\/wp-content\/uploads\/2017\/12\/ton-wesseling-1x1-bw-transparent-150x150.png"
+    }
+  },
+  {
+    "id": 442534,
+    "title": {
+      "raw": "Do conversion A\/B testing"
+    },
+    "content": {
+      "cxl_get_extended_main": "<p>This is an example description of a Playboom. Below are the breacrumbs that are taken directly from the fake JSON definition.<\/p>"
+    },
+    "featured_media": 1497178,
+    "categories": [
+      562
+    ],
+    "cxl_item_type": "hub",
+    "cxl_breadcrumbs": ["breadcrumbs", "only", "three", "of", "five"],
+    "cxl_steps_count": 10,
+    "cxl_author": "Mr Author",
+    "conversionxl_certificate_sales_page": "https:\/\/cxl.com\/institute\/online-course\/ab-testing-mastery\/",
+    "conversionxl_live_course_duration": "8h",
+    "cxl_hybrid_attr_post": {
+      "@attributes": {
+        "class": "entry author-maddie-sidoff-3 has-more-link post-442534 certificate type-certificate status-publish has-post-thumbnail category-online-trainings membership-content access-granted format-previously live column pure-u-1 pure-u-sm-1-2 pure-u-lg-1-3",
+        "itemscope": "itemscope",
+        "itemtype": "http:\/\/schema.org\/CreativeWork",
+        "id": "post-442534"
+      }
+    },
+    "cxl_featured_media": {
+      "shop_catalog": "https:\/\/cxl.com\/institute\/wp-content\/uploads\/2017\/12\/ton-wesseling-1x1-bw-transparent-150x150.png"
+    }
   }
 ]

--- a/packages/storybook/cxl-hubpage/cxl-hubpage.stories.js
+++ b/packages/storybook/cxl-hubpage/cxl-hubpage.stories.js
@@ -1,3 +1,4 @@
+import '@appnest/masonry-layout';
 import { html } from 'lit-html';
 import { withKnobs, boolean } from '@storybook/addon-knobs';
 import '@conversionxl/cxl-ui/src/components/cxl-app-layout.js';
@@ -15,15 +16,6 @@ export const CXLDHubPage = () => {
   const hasWidgetBackground = boolean('Has widget background?', false);
 
   return html`
-    <style>
-      .widget.has-background {
-        background-color: var(--lumo-shade-5pct);
-      }
-      .plural .entry-title {
-        margin: 0;
-      }
-    </style>
-
     <cxl-app-layout
       id="container"
       layout="2c-r"
@@ -45,7 +37,9 @@ export const CXLDHubPage = () => {
             id="cxl-vaadin-accordion-26107"
             class="archive archive-certificate plural"
             theme="cxl-hub-cards"
-          >${RenderHubs()}${RenderPlaybooks()}</cxl-vaadin-accordion>
+          >
+            <masonry-layout cols="auto" maxcolwidth="768" gap="16">${RenderHubs()}${RenderPlaybooks()}</masonry-layout>
+          </cxl-vaadin-accordion>
         </div>
       </article>
     </cxl-app-layout>

--- a/packages/storybook/cxl-hubpage/cxl-hubpage.stories.js
+++ b/packages/storybook/cxl-hubpage/cxl-hubpage.stories.js
@@ -1,0 +1,51 @@
+import { html } from 'lit-html';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
+import '@conversionxl/cxl-ui/src/components/cxl-app-layout.js';
+
+export default {
+  decorators: [withKnobs],
+  title: 'CXL Hub Page',
+};
+
+export const CXLDHubPage = () => {
+  const hasPanelsScroll = boolean('Has panels scroll?', true);
+  const hasWidgetBackground = boolean('Has widget background?', false);
+
+  return html`
+    <style>
+      .widget.has-background {
+        background-color: var(--lumo-shade-5pct);
+      }
+    </style>
+
+    <cxl-app-layout
+      id="container"
+      layout="2c-l"
+      scroll="${hasPanelsScroll ? 'panels' : 'document'}"
+    >
+      <section class="widget ${hasWidgetBackground ? 'has-background' : ''}" slot="sidebar">
+        <label>Widget</label>
+        <h3 class="widget-title">Menu</h3>
+        <ul>
+          <li>Menu item 1</li>
+          <li>Menu item 2</li>
+          <li>Menu item 3</li>
+        </ul>
+      </section>
+
+      <article class="entry">
+        <header class="entry-header">
+          <label>Page</label>
+          <h1 class="entry-title">Title: 2-column, content left</h1>
+          <p>Lorem ipsum....</p>
+        </header>
+        <div class="entry-content">
+          <h2>Headline</h2>
+          <p>Lorem ipsum....</p>
+        </div>
+      </article>
+    </cxl-app-layout>
+  `;
+};
+
+CXLDHubPage.storyName = '[cxl-hubpage]';

--- a/packages/storybook/cxl-hubpage/cxl-hubpage.stories.js
+++ b/packages/storybook/cxl-hubpage/cxl-hubpage.stories.js
@@ -1,6 +1,9 @@
 import { html } from 'lit-html';
 import { withKnobs, boolean } from '@storybook/addon-knobs';
 import '@conversionxl/cxl-ui/src/components/cxl-app-layout.js';
+import '@conversionxl/cxl-ui/src/components/cxl-vaadin-accordion.js';
+import RenderHubs from './cxl-hubpage-render-hubs';
+import RenderPlaybooks from './cxl-hubpage-render-playbooks';
 
 export default {
   decorators: [withKnobs],
@@ -16,11 +19,14 @@ export const CXLDHubPage = () => {
       .widget.has-background {
         background-color: var(--lumo-shade-5pct);
       }
+      .plural .entry-title {
+        margin: 0;
+      }
     </style>
 
     <cxl-app-layout
       id="container"
-      layout="2c-l"
+      layout="2c-r"
       scroll="${hasPanelsScroll ? 'panels' : 'document'}"
     >
       <section class="widget ${hasWidgetBackground ? 'has-background' : ''}" slot="sidebar">
@@ -34,14 +40,12 @@ export const CXLDHubPage = () => {
       </section>
 
       <article class="entry">
-        <header class="entry-header">
-          <label>Page</label>
-          <h1 class="entry-title">Title: 2-column, content left</h1>
-          <p>Lorem ipsum....</p>
-        </header>
-        <div class="entry-content">
-          <h2>Headline</h2>
-          <p>Lorem ipsum....</p>
+        <div class="entry-content"></div>
+          <cxl-vaadin-accordion
+            id="cxl-vaadin-accordion-26107"
+            class="archive archive-certificate plural"
+            theme="cxl-hub-cards"
+          >${RenderHubs()}${RenderPlaybooks()}</cxl-vaadin-accordion>
         </div>
       </article>
     </cxl-app-layout>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@appnest/masonry-layout@^2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@appnest/masonry-layout/-/masonry-layout-2.0.8.tgz#b4c1a340dc515c9222d70e8d21b9da64e647f4fc"
+  integrity sha512-kpUh19QrwpADbyRQdXqG3MPMYSdtLmaq45v4JSbmjGa+VU4ZMC11w7kZx18iSzPeQHAdBF+p4CVsCTgtZNll/A==
+
 "@babel/code-frame@7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"


### PR DESCRIPTION

https://user-images.githubusercontent.com/36610000/108833558-4ae1f580-75cd-11eb-9cc7-5c57afe2aa6e.mp4

Description:

- To create behavious as found on "1-mvp hubpage" ( https://www.figma.com/file/kEdgO7kNJbkPBLMJ2YQFt0/CXL-Playbooks-(cxl-copy)?node-id=934%3A1920 ) there was a need to use a masonry-like system of grids. Added webcomponent: https://www.webcomponents.org/element/@appnest/masonry-layout

- To create initial looks of the 2 card types (black - for hubs, white - for playbooks) additional, temporal css theme for "Vaadin Accordion" added named "cxl-hub-cards". 