### PR TITLE
build(cli deploy): bump storybook-deployer to 2.8.8

### DIFF
--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -16,7 +16,7 @@
     "@storybook/addons": "^6.1.21",
     "@storybook/client-api": "^6.1.21",
     "@storybook/core": "^6.1.21",
-    "@storybook/storybook-deployer": "^2.8.1",
+    "@storybook/storybook-deployer": "^2.8.8",
     "@storybook/web-components": "^6.1.21",
     "@vaadin/vaadin-button": "^3.0.0-alpha1",
     "@vaadin/vaadin-notification": "^2.0.0-alpha1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2975,10 +2975,10 @@
     core-js "^3.6.5"
     find-up "^4.1.0"
 
-"@storybook/storybook-deployer@^2.8.1":
-  version "2.8.7"
-  resolved "https://registry.yarnpkg.com/@storybook/storybook-deployer/-/storybook-deployer-2.8.7.tgz#c1eed33d03bd9267f884c60eea8e03dc3261ec11"
-  integrity sha512-O0hKHV6hg93fPMvKGC5M/sd7KTL473+SzMKm+WZNVEyLEfXXcVU+Ts9/VL1IhmC1P2A8Bg9oBnkcPqAqjAN46w==
+"@storybook/storybook-deployer@^2.8.8":
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/@storybook/storybook-deployer/-/storybook-deployer-2.8.8.tgz#680a46de7c5b78ac3f4b319f30a358aab0bd1907"
+  integrity sha512-nRdK7llDJR1ayWt1354lLsrPuKzVmLPk9kxOzMo2EirumMkyUNIdZH+voHdntUKkh+KuSOm7Q0OOoqlHZkY0vA==
   dependencies:
     git-url-parse "^11.1.2"
     glob "^7.1.3"


### PR DESCRIPTION
Related to the latest fix in `storybook deployer`: https://github.com/storybookjs/storybook-deployer/pull/102