### PR TITLE
cxl paywall message

### DIFF
--- a/packages/cxl-ui/src/components/cxl-paywall.js
+++ b/packages/cxl-ui/src/components/cxl-paywall.js
@@ -1,5 +1,6 @@
 import '@vaadin/vaadin-dialog';
 import { customElement, html, LitElement, property, query } from 'lit-element';
+import { render } from 'lit-html';
 
 @customElement('cxl-paywall')
 export class CXLPaywallElement extends LitElement {
@@ -21,6 +22,10 @@ export class CXLPaywallElement extends LitElement {
 
   @query('#content') content;
 
+  @query('vaadin-dialog') dialog;
+
+  @query("slot[name='message']") messageSlot;
+
   _animation;
 
   _clickListener;
@@ -29,6 +34,7 @@ export class CXLPaywallElement extends LitElement {
 
   render() {
     return html`
+      <slot name="message"></slot>
       <div id="content">
         <slot></slot>
       </div>
@@ -37,9 +43,7 @@ export class CXLPaywallElement extends LitElement {
         no-close-on-esc
         no-close-on-outside-click
         ?opened=${this._shouldSubscribe}
-      >
-        <template> You have reached you're limit of free playbooks, please sign-up here. </template>
-      </vaadin-dialog>
+      ></vaadin-dialog>
     `;
   }
 
@@ -58,6 +62,7 @@ export class CXLPaywallElement extends LitElement {
   }
 
   firstUpdated() {
+    this._setRenderer();
     this._checkDate();
     this._increment();
   }
@@ -143,6 +148,12 @@ export class CXLPaywallElement extends LitElement {
 
     const month = localStorage.getItem('cxl-paywall-month');
     if (month !== undefined) this._month = Number(month);
+  }
+
+  _setRenderer() {
+    this.dialog.renderer = (root) => {
+      render(this.messageSlot.assignedNodes()[0].children[0], root);
+    };
   }
 
   /**

--- a/packages/cxl-ui/src/components/cxl-paywall.js
+++ b/packages/cxl-ui/src/components/cxl-paywall.js
@@ -1,5 +1,5 @@
 import '@vaadin/vaadin-dialog';
-import { customElement, html, LitElement, property, query } from 'lit-element';
+import { css, customElement, html, LitElement, property, query } from 'lit-element';
 import { render } from 'lit-html';
 
 @customElement('cxl-paywall')
@@ -31,6 +31,16 @@ export class CXLPaywallElement extends LitElement {
   _clickListener;
 
   _hidden = false;
+
+  static get styles() {
+    return [
+      css`
+        slot[name='message'] {
+          display: none;
+        }
+      `,
+    ];
+  }
 
   render() {
     return html`

--- a/packages/storybook/cxl-ui/cxl-paywall.stories.js
+++ b/packages/storybook/cxl-ui/cxl-paywall.stories.js
@@ -10,13 +10,20 @@ export default {
   component: 'cxl-paywall',
 };
 
-const Template = ({ _count, _limit, delay, opacity, subscribed }) => {
-  return html`
-    <cxl-paywall ._count=${_count} ._limit=${_limit} delay=${delay} opacity=${opacity} ?subscribed=${subscribed}>
-      ${unsafeHTML(content)}
-    </cxl-paywall>
-  `;
-};
+const Template = ({ _count, _limit, delay, message, opacity, subscribed }) => html`
+  <cxl-paywall
+    ._count=${_count}
+    ._limit=${_limit}
+    delay=${delay}
+    opacity=${opacity}
+    ?subscribed=${subscribed}
+  >
+    <div slot="message">
+      <span>${message}</span>
+    </div>
+    ${unsafeHTML(content)}
+  </cxl-paywall>
+`;
 
 export const Default = (args) => Template(args);
 
@@ -24,6 +31,7 @@ Default.args = {
   _count: 0,
   _limit: 10,
   delay: 1000,
+  message: "You have reached you're limit of free playbooks.",
   opacity: 0.2,
   subscribed: false,
 };
@@ -38,6 +46,9 @@ Default.argTypes = {
   },
   delay: {
     name: 'Delay',
+  },
+  message: {
+    name: 'Message',
   },
   opacity: {
     name: 'Opacity',


### PR DESCRIPTION
Adds the ability to specify the dialog content from the outside. Constraints are that `<div slot="message"></div>` needs to have only one direct child to act as the wrapper.

```
<cxl-paywall>
  <div slot="message">
    <div id="sample-wrapper">###DIALOG CONTENT###</div>
  </div>
  ###CONTENT###
</cxl-paywall>
```

It should support text/html.