### PR TITLE
refactor(cxl-ui): disable showing votes count if no votes cast yet

### DIFF
--- a/packages/cxl-ui/src/components/cxl-like-or-dislike.js
+++ b/packages/cxl-ui/src/components/cxl-like-or-dislike.js
@@ -147,7 +147,7 @@ export class CXLLikeOrDislikeElement extends LitElement {
     const plural = this.upVotes !== 1 ? 's' : '';
 
     return html`<div>
-      <div counter>${this.upVotes} Vote${plural}</div>
+      ${this.upVotes > 0 ? html`<div counter>${this.upVotes} Vote${plural}</div>` : ''}
       <div class="vote" @click="${this._upVote}" up>
         <iron-icon icon="vaadin:thumbs-up-o"></iron-icon><span>Upvote${d1}</span>
       </div>


### PR DESCRIPTION
reference: https://cxlworld.slack.com/archives/C01JABH8AHX/p1633356368056300

I saw that Paul made a pull request concerning hiding the 0 count on the list view ( https://github.com/conversionxl/cxl-playbook-blocks/pull/288 ) and this one , if needed, would hide the 0 count on a singular playbook.