### PR TITLE
organize imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,9 @@
     "import/extensions": "off",
     "import/prefer-default-export": "off",
     "no-restricted-globals": "off",
-    "no-underscore-dangle": "off"
+    "no-underscore-dangle": "off",
+    "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error"
   },
   "overrides": [
     {
@@ -51,5 +53,6 @@
     },
     "ecmaVersion": 2018,
     "sourceType": "module"
-  }
+  },
+  "plugins": ["simple-import-sort"]
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-lit": "^1.2.2",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "husky": "^4.3.8",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^4.1.0",
@@ -101,7 +102,9 @@
   },
   "size-limit": [
     {
-      "path": ["packages/cxl-ui/pkg/dist-web/cxl-ui*.js"]
+      "path": [
+        "packages/cxl-ui/pkg/dist-web/cxl-ui*.js"
+      ]
     }
   ]
 }

--- a/packages/core/src/components/button.js
+++ b/packages/core/src/components/button.js
@@ -10,8 +10,8 @@ export class ButtonElement extends DelegateFocusMixin(LitElement) {
        */
       link: {
         type: String,
-        reflect: true
-      }
+        reflect: true,
+      },
     };
   }
 

--- a/packages/core/src/components/button.js
+++ b/packages/core/src/components/button.js
@@ -1,4 +1,5 @@
-import { LitElement, html } from 'lit-element';
+import { html, LitElement } from 'lit-element';
+
 import { DelegateFocusMixin } from '../mixins/delegate-focus-mixin.js';
 import buttonBaseStyles from '../styles/button-base-css.js';
 

--- a/packages/core/src/components/checkbox.js
+++ b/packages/core/src/components/checkbox.js
@@ -1,4 +1,5 @@
-import { LitElement, html } from 'lit-element';
+import { html, LitElement } from 'lit-element';
+
 import { DelegateFocusMixin } from '../mixins/delegate-focus-mixin.js';
 import checkboxBaseStyles from '../styles/checkbox-base-css.js';
 

--- a/packages/core/src/components/checkbox.js
+++ b/packages/core/src/components/checkbox.js
@@ -12,7 +12,7 @@ export class CheckboxElement extends DelegateFocusMixin(LitElement) {
        */
       checked: {
         type: Boolean,
-        reflect: true
+        reflect: true,
       },
 
       /**
@@ -21,7 +21,7 @@ export class CheckboxElement extends DelegateFocusMixin(LitElement) {
        */
       indeterminate: {
         type: Boolean,
-        reflect: true
+        reflect: true,
       },
 
       /**
@@ -29,8 +29,8 @@ export class CheckboxElement extends DelegateFocusMixin(LitElement) {
        * to the server when the checkbox is inside a form.
        */
       value: {
-        reflect: true
-      }
+        reflect: true,
+      },
     };
   }
 
@@ -105,7 +105,7 @@ export class CheckboxElement extends DelegateFocusMixin(LitElement) {
     }
     this.dispatchEvent(
       new CustomEvent('checked-changed', {
-        detail: { value: checked }
+        detail: { value: checked },
       })
     );
   }
@@ -127,10 +127,10 @@ export class CheckboxElement extends DelegateFocusMixin(LitElement) {
     // into the ancestor tree, so we must do this manually.
     const changeEvent = new CustomEvent('change', {
       detail: {
-        sourceEvent: e
+        sourceEvent: e,
       },
       bubbles: e.bubbles,
-      cancelable: e.cancelable
+      cancelable: e.cancelable,
     });
     this.dispatchEvent(changeEvent);
   }

--- a/packages/core/src/components/progress.js
+++ b/packages/core/src/components/progress.js
@@ -10,7 +10,7 @@ export class ProgressElement extends LitElement {
        * or empty string to set indeterminate state.
        */
       value: {
-        type: Number
+        type: Number,
       },
 
       /**
@@ -18,8 +18,8 @@ export class ProgressElement extends LitElement {
        * Note: the minimum value is always 0.
        */
       max: {
-        type: Number
-      }
+        type: Number,
+      },
     };
   }
 
@@ -39,8 +39,6 @@ export class ProgressElement extends LitElement {
     if (value === null || value === '') {
       value = undefined;
     }
-    return html`
-      <progress value="${ifDefined(value)}" max="${this.max}"></progress>
-    `;
+    return html` <progress value="${ifDefined(value)}" max="${this.max}"></progress> `;
   }
 }

--- a/packages/core/src/components/progress.js
+++ b/packages/core/src/components/progress.js
@@ -1,5 +1,6 @@
-import { LitElement, html } from 'lit-element';
+import { html, LitElement } from 'lit-element';
 import { ifDefined } from 'lit-html/directives/if-defined';
+
 import progressBaseStyles from '../styles/progress-base-css.js';
 
 export class ProgressElement extends LitElement {

--- a/packages/core/src/components/range.js
+++ b/packages/core/src/components/range.js
@@ -3,26 +3,26 @@ import { ifDefined } from 'lit-html/directives/if-defined';
 import { DelegateFocusMixin } from '../mixins/delegate-focus-mixin.js';
 import rangeBaseStyles from '../styles/range-base-css.js';
 
-const isNumeric = n => !isNaN(parseFloat(n)) && isFinite(n);
+const isNumeric = (n) => !isNaN(parseFloat(n)) && isFinite(n);
 
 export class RangeElement extends DelegateFocusMixin(LitElement) {
   static get properties() {
     return {
       value: {
-        type: Number
+        type: Number,
       },
 
       min: {
-        type: Number
+        type: Number,
       },
 
       max: {
-        type: Number
+        type: Number,
       },
 
       step: {
-        type: Number
-      }
+        type: Number,
+      },
     };
   }
 
@@ -98,8 +98,8 @@ export class RangeElement extends DelegateFocusMixin(LitElement) {
       this.dispatchEvent(
         new CustomEvent('value-changed', {
           detail: {
-            value: this.value
-          }
+            value: this.value,
+          },
         })
       );
     }
@@ -114,10 +114,10 @@ export class RangeElement extends DelegateFocusMixin(LitElement) {
     // into the ancestor tree, so we must do this manually.
     const changeEvent = new CustomEvent('change', {
       detail: {
-        sourceEvent: e
+        sourceEvent: e,
       },
       bubbles: e.bubbles,
-      cancelable: e.cancelable
+      cancelable: e.cancelable,
     });
     this.dispatchEvent(changeEvent);
   }

--- a/packages/core/src/components/range.js
+++ b/packages/core/src/components/range.js
@@ -1,5 +1,6 @@
-import { LitElement, html } from 'lit-element';
+import { html, LitElement } from 'lit-element';
 import { ifDefined } from 'lit-html/directives/if-defined';
+
 import { DelegateFocusMixin } from '../mixins/delegate-focus-mixin.js';
 import rangeBaseStyles from '../styles/range-base-css.js';
 

--- a/packages/core/src/components/switch.js
+++ b/packages/core/src/components/switch.js
@@ -10,8 +10,8 @@ export class SwitchElement extends DelegateFocusMixin(LitElement) {
        */
       checked: {
         type: Boolean,
-        reflect: true
-      }
+        reflect: true,
+      },
     };
   }
 
@@ -64,7 +64,7 @@ export class SwitchElement extends DelegateFocusMixin(LitElement) {
     this.setAttribute('aria-checked', checked);
     this.dispatchEvent(
       new CustomEvent('checked-changed', {
-        detail: { value: checked }
+        detail: { value: checked },
       })
     );
   }
@@ -77,10 +77,10 @@ export class SwitchElement extends DelegateFocusMixin(LitElement) {
     // into the ancestor tree, so we must do this manually.
     const changeEvent = new CustomEvent('change', {
       detail: {
-        sourceEvent: e
+        sourceEvent: e,
       },
       bubbles: e.bubbles,
-      cancelable: e.cancelable
+      cancelable: e.cancelable,
     });
     this.dispatchEvent(changeEvent);
   }

--- a/packages/core/src/components/switch.js
+++ b/packages/core/src/components/switch.js
@@ -1,4 +1,5 @@
-import { LitElement, html } from 'lit-element';
+import { html, LitElement } from 'lit-element';
+
 import { DelegateFocusMixin } from '../mixins/delegate-focus-mixin.js';
 import switchBaseStyles from '../styles/switch-base-css.js';
 

--- a/packages/core/src/mixins/delegate-focus-mixin.js
+++ b/packages/core/src/mixins/delegate-focus-mixin.js
@@ -2,17 +2,17 @@ const $$tabindex = Symbol('tabindex');
 const $$oldTabindex = Symbol('oldTabindex');
 const $$newTabindex = Symbol('newTabindex');
 
-export const DelegateFocusMixin = superClass =>
+export const DelegateFocusMixin = (superClass) =>
   class extends superClass {
     static get properties() {
       return {
         tabIndex: {
           converter: {
             fromAttribute: Number,
-            toAttribute: value => (value == null ? null : value.toString())
+            toAttribute: (value) => (value == null ? null : value.toString()),
           },
           noAccessor: true,
-          reflect: true
+          reflect: true,
         },
 
         /**
@@ -20,8 +20,8 @@ export const DelegateFocusMixin = superClass =>
          */
         disabled: {
           type: Boolean,
-          reflect: true
-        }
+          reflect: true,
+        },
       };
     }
 
@@ -43,13 +43,13 @@ export const DelegateFocusMixin = superClass =>
     }
 
     firstUpdated() {
-      this.addEventListener('focusin', e => {
+      this.addEventListener('focusin', (e) => {
         if (e.composedPath()[0] === this) {
           this._focus();
         }
       });
 
-      this.addEventListener('keydown', e => {
+      this.addEventListener('keydown', (e) => {
         if (!e.defaultPrevented && e.shiftKey && e.keyCode === 9) {
           // Flag is checked in _focus event handler.
           this._isShiftTabbing = true;

--- a/packages/core/src/mixins/item-mixin.js
+++ b/packages/core/src/mixins/item-mixin.js
@@ -1,4 +1,4 @@
-export const ItemMixin = superClass =>
+export const ItemMixin = (superClass) =>
   class extends superClass {
     /**
      * Used for mixin detection because `instanceof` does not work with mixins.
@@ -14,7 +14,7 @@ export const ItemMixin = superClass =>
          */
         disabled: {
           type: Boolean,
-          reflect: true
+          reflect: true,
         },
 
         /**
@@ -22,8 +22,8 @@ export const ItemMixin = superClass =>
          */
         selected: {
           type: Boolean,
-          reflect: true
-        }
+          reflect: true,
+        },
       };
     }
 
@@ -56,8 +56,8 @@ export const ItemMixin = superClass =>
         };
         document.addEventListener('mouseup', mouseUpListener);
       });
-      this.addEventListener('keydown', e => this._onKeydown(e));
-      this.addEventListener('keyup', e => this._onKeyup(e));
+      this.addEventListener('keydown', (e) => this._onKeydown(e));
+      this.addEventListener('keyup', (e) => this._onKeyup(e));
     }
 
     _selectedChanged(selected) {

--- a/packages/core/tests/button.spec.js
+++ b/packages/core/tests/button.spec.js
@@ -1,4 +1,5 @@
 import { defineCE, fixture } from '@open-wc/testing-helpers';
+
 import { ButtonElement } from '../src/components/button.js';
 
 describe('button', () => {

--- a/packages/core/tests/checkbox.spec.js
+++ b/packages/core/tests/checkbox.spec.js
@@ -1,4 +1,5 @@
 import { defineCE, fixture } from '@open-wc/testing-helpers';
+
 import { CheckboxElement } from '../src/components/checkbox.js';
 
 describe('checkbox', () => {

--- a/packages/core/tests/delegate-focus-mixin.spec.js
+++ b/packages/core/tests/delegate-focus-mixin.spec.js
@@ -1,6 +1,7 @@
-import { LitElement } from 'lit-element';
 import { focusin, shiftTabDown, shiftTabEvent } from '@aybolit/test-helpers';
 import { defineCE, fixture, html } from '@open-wc/testing-helpers';
+import { LitElement } from 'lit-element';
+
 import { DelegateFocusMixin } from '../src/mixins/delegate-focus-mixin.js';
 
 const TestElement = defineCE(

--- a/packages/core/tests/delegate-focus-mixin.spec.js
+++ b/packages/core/tests/delegate-focus-mixin.spec.js
@@ -6,9 +6,7 @@ import { DelegateFocusMixin } from '../src/mixins/delegate-focus-mixin.js';
 const TestElement = defineCE(
   class extends DelegateFocusMixin(LitElement) {
     render() {
-      return html`
-        <input id="input" /><input id="secondInput" />
-      `;
+      return html` <input id="input" /><input id="secondInput" /> `;
     }
 
     get focusElement() {
@@ -152,13 +150,13 @@ describe('delegate-focus-mixin', () => {
       Object.defineProperty(event, 'defaultPrevented', {
         get() {
           return true;
-        }
+        },
       });
       customElement.dispatchEvent(event);
       expect(customElement._isShiftTabbing).not.to.be.ok;
     });
 
-    it('should refocus the field', done => {
+    it('should refocus the field', (done) => {
       focusin(customElement);
       shiftTabDown(document.body);
 

--- a/packages/core/tests/item-mixin.spec.js
+++ b/packages/core/tests/item-mixin.spec.js
@@ -8,7 +8,7 @@ import {
   blur,
   focus,
   mousedown,
-  mouseup
+  mouseup,
 } from '@aybolit/test-helpers';
 import { ItemMixin } from '../src/mixins/item-mixin.js';
 
@@ -16,9 +16,7 @@ describe('item-mixin', () => {
   const Item = defineCE(
     class extends ItemMixin(LitElement) {
       render() {
-        return html`
-          <div><slot></slot></div>
-        `;
+        return html` <div><slot></slot></div> `;
       }
     }
   );

--- a/packages/core/tests/item-mixin.spec.js
+++ b/packages/core/tests/item-mixin.spec.js
@@ -1,15 +1,16 @@
-import { LitElement, html } from 'lit-element';
-import { defineCE, fixture } from '@open-wc/testing-helpers';
 import {
-  enter,
-  spaceDown,
-  spaceUp,
-  space,
   blur,
+  enter,
   focus,
   mousedown,
   mouseup,
+  space,
+  spaceDown,
+  spaceUp,
 } from '@aybolit/test-helpers';
+import { defineCE, fixture } from '@open-wc/testing-helpers';
+import { html, LitElement } from 'lit-element';
+
 import { ItemMixin } from '../src/mixins/item-mixin.js';
 
 describe('item-mixin', () => {

--- a/packages/core/tests/progress.spec.js
+++ b/packages/core/tests/progress.spec.js
@@ -1,5 +1,6 @@
-import { defineCE, fixture } from '@open-wc/testing-helpers';
 import { matchesSelector } from '@aybolit/test-helpers';
+import { defineCE, fixture } from '@open-wc/testing-helpers';
+
 import { ProgressElement } from '../src/components/progress.js';
 
 describe('progress', () => {

--- a/packages/core/tests/range.spec.js
+++ b/packages/core/tests/range.spec.js
@@ -1,4 +1,5 @@
 import { defineCE, fixture } from '@open-wc/testing-helpers';
+
 import { RangeElement } from '../src/components/range.js';
 
 describe('range', () => {

--- a/packages/core/tests/switch.spec.js
+++ b/packages/core/tests/switch.spec.js
@@ -1,4 +1,5 @@
 import { defineCE, fixture } from '@open-wc/testing-helpers';
+
 import { SwitchElement } from '../src/components/switch.js';
 
 describe('switch', () => {

--- a/packages/cxl-lumo-styles/src/color.js
+++ b/packages/cxl-lumo-styles/src/color.js
@@ -1,4 +1,5 @@
 import '@vaadin/vaadin-lumo-styles/color.js';
+
 import styles from './styles/color-css.js';
 
 const $template = document.createElement('template');

--- a/packages/cxl-lumo-styles/src/icons.js
+++ b/packages/cxl-lumo-styles/src/icons.js
@@ -1,9 +1,11 @@
-import { css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
-import { registerGlobalStyles } from './utils.js';
 import '@vaadin/vaadin-lumo-styles/font-icons.js';
 import '@vaadin/vaadin-lumo-styles/icons.js';
 import '@vaadin/vaadin-lumo-styles/sizing.js';
 import '@polymer/iron-iconset-svg/iron-iconset-svg.js';
+
+import { css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+
+import { registerGlobalStyles } from './utils.js';
 
 registerGlobalStyles(
   css`

--- a/packages/cxl-lumo-styles/src/index.js
+++ b/packages/cxl-lumo-styles/src/index.js
@@ -2,8 +2,9 @@ import './color.js';
 import './typography.js';
 import './icons.js';
 import './themes.js';
-import { registerGlobalStyles } from './utils.js';
+
 import globalStyles from './styles/global-css.js';
+import { registerGlobalStyles } from './utils.js';
 
 registerGlobalStyles(globalStyles, {
   moduleId: 'cxl-lumo-styles-global',

--- a/packages/cxl-lumo-styles/src/themes.js
+++ b/packages/cxl-lumo-styles/src/themes.js
@@ -1,4 +1,5 @@
 import { registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
+
 import cxlAccordionCardStyles from './styles/themes/cxl-accordion-card-css.js';
 import cxlTabsSliderStyles from './styles/themes/cxl-tabs-slider-css.js';
 import cxlVaadinAccordionStyles from './styles/themes/vaadin-accordion-css.js';

--- a/packages/cxl-lumo-styles/src/typography.js
+++ b/packages/cxl-lumo-styles/src/typography.js
@@ -1,4 +1,5 @@
 import '@vaadin/vaadin-lumo-styles/typography.js';
+
 import styles from './styles/typography-css.js';
 
 const $template = document.createElement('template');

--- a/packages/cxl-ui/src/components/cxl-accordion-card.js
+++ b/packages/cxl-ui/src/components/cxl-accordion-card.js
@@ -1,6 +1,7 @@
-import { customElement } from 'lit-element';
 import '@conversionxl/cxl-lumo-styles';
+
 import { AccordionPanelElement } from '@vaadin/vaadin-accordion/src/vaadin-accordion-panel';
+import { customElement } from 'lit-element';
 
 @customElement('cxl-accordion-card')
 export class CXLAccordionCardElement extends AccordionPanelElement {

--- a/packages/cxl-ui/src/components/cxl-app-layout.js
+++ b/packages/cxl-ui/src/components/cxl-app-layout.js
@@ -1,14 +1,16 @@
 /**
  * @todo implement primary action button.
  */
-import { LitElement, html, customElement, property, query } from 'lit-element';
 import '@conversionxl/cxl-lumo-styles';
-import { registerGlobalStyles } from '@conversionxl/cxl-lumo-styles/src/utils';
-import normalizeWheel from '@conversionxl/normalize-wheel';
-import cxlAppLayoutStyles from '../styles/cxl-app-layout-css.js';
-import cxlAppLayoutGlobalStyles from '../styles/global/cxl-app-layout-css.js';
 import '@vaadin/vaadin-button';
 import '@vaadin/vaadin-context-menu/src/vaadin-device-detector.js';
+
+import { registerGlobalStyles } from '@conversionxl/cxl-lumo-styles/src/utils';
+import normalizeWheel from '@conversionxl/normalize-wheel';
+import { customElement, html, LitElement, property, query } from 'lit-element';
+
+import cxlAppLayoutStyles from '../styles/cxl-app-layout-css.js';
+import cxlAppLayoutGlobalStyles from '../styles/global/cxl-app-layout-css.js';
 
 const ASIDE_LOCAL_STORAGE_KEY = 'cxl-app-layout-aside-opened';
 

--- a/packages/cxl-ui/src/components/cxl-card.js
+++ b/packages/cxl-ui/src/components/cxl-card.js
@@ -1,8 +1,10 @@
-import { customElement, LitElement, html } from 'lit-element';
 import '@conversionxl/cxl-lumo-styles';
+
 import { registerGlobalStyles } from '@conversionxl/cxl-lumo-styles/src/utils';
-import cxlCardGlobalStyles from '../styles/global/cxl-card-css.js';
+import { customElement, html, LitElement } from 'lit-element';
+
 import cxlCardStyles from '../styles/cxl-card-css.js';
+import cxlCardGlobalStyles from '../styles/global/cxl-card-css.js';
 
 @customElement('cxl-card')
 export class CXLCardElement extends LitElement {

--- a/packages/cxl-ui/src/components/cxl-like-or-dislike.js
+++ b/packages/cxl-ui/src/components/cxl-like-or-dislike.js
@@ -1,5 +1,7 @@
-import { customElement, LitElement, html, property, query, queryAll } from 'lit-element';
 import '@conversionxl/cxl-lumo-styles';
+
+import { customElement, html, LitElement, property, query, queryAll } from 'lit-element';
+
 import cxlLikeOrDislikeStyles from '../styles/cxl-like-or-dislike-css.js';
 
 @customElement('cxl-like-or-dislike')

--- a/packages/cxl-ui/src/components/cxl-marketing-nav.js
+++ b/packages/cxl-ui/src/components/cxl-marketing-nav.js
@@ -132,9 +132,8 @@ export class CXLMarketingNavElement extends LitElement {
     /**
      * Configure `.menu-item-search`.
      */
-    const menuItemSearchContextMenu = this.menuItemSearchElement.querySelector(
-      'vaadin-context-menu'
-    );
+    const menuItemSearchContextMenu =
+      this.menuItemSearchElement.querySelector('vaadin-context-menu');
 
     /**
      * `<vaadin-context-menu-item>` interferes with form input.

--- a/packages/cxl-ui/src/components/cxl-marketing-nav.js
+++ b/packages/cxl-ui/src/components/cxl-marketing-nav.js
@@ -1,11 +1,13 @@
-import { LitElement, html, customElement, property, query } from 'lit-element';
 import '@conversionxl/cxl-lumo-styles';
-import { registerGlobalStyles } from '@conversionxl/cxl-lumo-styles/src/utils';
-import cxlMarketingNavStyles from '../styles/cxl-marketing-nav-css.js';
-import cxlMarketingNavGlobalStyles from '../styles/global/cxl-marketing-nav-css.js';
 import '@vaadin/vaadin-button';
 import '@vaadin/vaadin-tabs';
 import '@vaadin/vaadin-context-menu';
+
+import { registerGlobalStyles } from '@conversionxl/cxl-lumo-styles/src/utils';
+import { customElement, html, LitElement, property, query } from 'lit-element';
+
+import cxlMarketingNavStyles from '../styles/cxl-marketing-nav-css.js';
+import cxlMarketingNavGlobalStyles from '../styles/global/cxl-marketing-nav-css.js';
 
 @customElement('cxl-marketing-nav')
 export class CXLMarketingNavElement extends LitElement {

--- a/packages/cxl-ui/src/components/cxl-paywall.js
+++ b/packages/cxl-ui/src/components/cxl-paywall.js
@@ -1,4 +1,5 @@
 import '@vaadin/vaadin-dialog';
+
 import { css, customElement, html, LitElement, property, query } from 'lit-element';
 import { render } from 'lit-html';
 

--- a/packages/cxl-ui/src/components/cxl-playbook-accordion.js
+++ b/packages/cxl-ui/src/components/cxl-playbook-accordion.js
@@ -1,6 +1,8 @@
-import { customElement } from 'lit-element';
 import '@vaadin/vaadin-checkbox';
+
 import { registerGlobalStyles } from '@conversionxl/cxl-lumo-styles/src/utils';
+import { customElement } from 'lit-element';
+
 import cxlPlaybookAccordionGlobalStyles from '../styles/global/cxl-playbook-accordion-css.js';
 import { CXLVaadinAccordionElement } from './cxl-vaadin-accordion';
 

--- a/packages/cxl-ui/src/components/cxl-playbook-progress-bar.js
+++ b/packages/cxl-ui/src/components/cxl-playbook-progress-bar.js
@@ -1,7 +1,8 @@
-import { customElement } from 'lit-element';
 import '@conversionxl/cxl-lumo-styles';
+
 // import '@vaadin/vaadin-progress-bar';
 import { ProgressBarElement } from '@vaadin/vaadin-progress-bar/src/vaadin-progress-bar';
+import { customElement } from 'lit-element';
 
 @customElement('cxl-playbook-progress-bar')
 export class CXLPlaybookProgressBarElement extends ProgressBarElement {

--- a/packages/cxl-ui/src/components/cxl-save-favorite.js
+++ b/packages/cxl-ui/src/components/cxl-save-favorite.js
@@ -1,4 +1,5 @@
 import '@conversionxl/cxl-lumo-styles';
+
 import { customElement, html, LitElement, property, query } from 'lit-element';
 
 import cxlSaveFavoriteStyles from '../styles/cxl-save-favorite-css';

--- a/packages/cxl-ui/src/components/cxl-section.js
+++ b/packages/cxl-ui/src/components/cxl-section.js
@@ -1,5 +1,7 @@
-import { LitElement, customElement, html, svg } from 'lit-element';
 import '@conversionxl/cxl-lumo-styles';
+
+import { customElement, html, LitElement, svg } from 'lit-element';
+
 import cxlSectionStyles from '../styles/cxl-section-css';
 
 @customElement('cxl-section')

--- a/packages/cxl-ui/src/components/cxl-star-rating.js
+++ b/packages/cxl-ui/src/components/cxl-star-rating.js
@@ -1,4 +1,5 @@
 import '@conversionxl/cxl-lumo-styles';
+
 import { IronStarRating } from '@cwmr/iron-star-rating';
 
 /**

--- a/packages/cxl-ui/src/components/cxl-tabs-slider.js
+++ b/packages/cxl-ui/src/components/cxl-tabs-slider.js
@@ -1,4 +1,5 @@
 import '@conversionxl/cxl-lumo-styles';
+
 import { TabsElement } from '@vaadin/vaadin-tabs';
 import { customElement } from 'lit-element';
 

--- a/packages/cxl-ui/src/components/cxl-vaadin-accordion.js
+++ b/packages/cxl-ui/src/components/cxl-vaadin-accordion.js
@@ -1,8 +1,10 @@
-import { customElement } from 'lit-element';
 import '@conversionxl/cxl-lumo-styles';
 import '@vaadin/vaadin-accordion';
-import { AccordionElement } from '@vaadin/vaadin-accordion/src/vaadin-accordion';
+
 import { registerGlobalStyles } from '@conversionxl/cxl-lumo-styles/src/utils';
+import { AccordionElement } from '@vaadin/vaadin-accordion/src/vaadin-accordion';
+import { customElement } from 'lit-element';
+
 import cxlVaadinAccordionGlobalStyles from '../styles/global/cxl-vaadin-accordion-css.js';
 
 /**

--- a/packages/cxl-ui/src/index-core.js
+++ b/packages/cxl-ui/src/index-core.js
@@ -1,5 +1,6 @@
 import '@vaadin/vaadin-notification';
 import '@vaadin/vaadin-progress-bar';
+
 import * as Headroom from 'headroom.js';
 
 export { CXLAppLayoutElement } from './components/cxl-app-layout.js';
@@ -9,6 +10,7 @@ export { CXLSectionElement } from './components/cxl-section.js';
 export { CXLTabsSliderElement } from './components/cxl-tabs-slider.js';
 
 // Order matters.
+// eslint-disable-next-line simple-import-sort/exports
 export { CXLVaadinAccordionElement } from './components/cxl-vaadin-accordion.js';
 export { CXLPlaybookProgressBarElement } from './components/cxl-playbook-progress-bar.js';
 export { CXLPlaybookAccordionElement } from './components/cxl-playbook-accordion.js';

--- a/packages/cxl-ui/src/index-playbooks.js
+++ b/packages/cxl-ui/src/index-playbooks.js
@@ -1,4 +1,4 @@
-export { CXLSaveFavoriteElement } from './components/cxl-save-favorite.js';
-export { CXLStarRatingElement } from './components/cxl-star-rating.js';
 export { CXLLikeOrDislikeElement } from './components/cxl-like-or-dislike.js';
 export { CXLPaywallElement } from './components/cxl-paywall.js';
+export { CXLSaveFavoriteElement } from './components/cxl-save-favorite.js';
+export { CXLStarRatingElement } from './components/cxl-star-rating.js';

--- a/packages/cxl-ui/src/index-storybook.js
+++ b/packages/cxl-ui/src/index-storybook.js
@@ -1,5 +1,6 @@
 import '@vaadin/vaadin-notification';
 import '@vaadin/vaadin-progress-bar';
+
 import * as Headroom from 'headroom.js';
 
 export { CXLAppLayoutElement } from './components/cxl-app-layout.js';
@@ -9,6 +10,7 @@ export { CXLSectionElement } from './components/cxl-section.js';
 export { CXLTabsSliderElement } from './components/cxl-tabs-slider.js';
 
 // Order matters.
+// eslint-disable-next-line simple-import-sort/exports
 export { CXLVaadinAccordionElement } from './components/cxl-vaadin-accordion.js';
 export { CXLPlaybookProgressBarElement } from './components/cxl-playbook-progress-bar.js';
 export { CXLPlaybookAccordionElement } from './components/cxl-playbook-accordion.js';

--- a/packages/storybook/cxl-lumo-styles/elements.stories.js
+++ b/packages/storybook/cxl-lumo-styles/elements.stories.js
@@ -1,8 +1,10 @@
 import '@conversionxl/cxl-lumo-styles';
 import '@vaadin/vaadin-button';
 import '@vaadin/vaadin-notification';
-import { html } from 'lit-html';
+
 import cxlLoadingStyles from '@conversionxl/cxl-lumo-styles/src/styles/loading-css.js';
+import { html } from 'lit-html';
+
 import { CXLAppLayout } from '../cxl-ui/cxl-app-layout/layout=1c.stories';
 
 export default {

--- a/packages/storybook/cxl-lumo-styles/typography.stories.js
+++ b/packages/storybook/cxl-lumo-styles/typography.stories.js
@@ -1,5 +1,6 @@
 import '@conversionxl/cxl-lumo-styles';
 import '@vaadin/vaadin-button';
+
 import { withKnobs } from '@storybook/addon-knobs';
 import { html } from 'lit-html';
 

--- a/packages/storybook/cxl-ui/cxl-app-layout/layout=1c-c.stories.js
+++ b/packages/storybook/cxl-ui/cxl-app-layout/layout=1c-c.stories.js
@@ -1,6 +1,8 @@
-import { html } from 'lit-html';
 import '@conversionxl/cxl-ui/src/components/cxl-app-layout.js';
 import '@conversionxl/cxl-ui/src/components/cxl-marketing-nav.js';
+
+import { html } from 'lit-html';
+
 import { CXLMarketingNav } from '../cxl-marketing-nav.stories';
 import { CXLFooterNav } from '../footer-nav.stories';
 

--- a/packages/storybook/cxl-ui/cxl-app-layout/layout=1c-w.stories.js
+++ b/packages/storybook/cxl-ui/cxl-app-layout/layout=1c-w.stories.js
@@ -1,9 +1,11 @@
-import { html } from 'lit-html';
 import '@conversionxl/cxl-ui/src/components/cxl-app-layout.js';
 import '@conversionxl/cxl-ui/src/components/cxl-marketing-nav.js';
+
+import { html } from 'lit-html';
+
 import { CXLMarketingNav } from '../cxl-marketing-nav.stories';
-import { CXLFooterNav } from '../footer-nav.stories';
 import { CXLVaadinAccordionThemeArchive } from '../cxl-vaadin-accordion.stories';
+import { CXLFooterNav } from '../footer-nav.stories';
 
 export default {
   title: 'CXL UI/cxl-app-layout',

--- a/packages/storybook/cxl-ui/cxl-app-layout/layout=1c.stories.js
+++ b/packages/storybook/cxl-ui/cxl-app-layout/layout=1c.stories.js
@@ -1,8 +1,10 @@
-import { html } from 'lit-html';
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
 import '@conversionxl/cxl-ui/src/components/cxl-app-layout.js';
 import '@conversionxl/cxl-ui/src/components/cxl-marketing-nav.js';
 import '@conversionxl/cxl-ui/src/components/cxl-section.js';
+
+import { boolean, text, withKnobs } from '@storybook/addon-knobs';
+import { html } from 'lit-html';
+
 import { CXLMarketingNav } from '../cxl-marketing-nav.stories';
 import { CXLFooterNav } from '../footer-nav.stories';
 

--- a/packages/storybook/cxl-ui/cxl-app-layout/layout=2c-l.stories.js
+++ b/packages/storybook/cxl-ui/cxl-app-layout/layout=2c-l.stories.js
@@ -1,9 +1,11 @@
-import { html } from 'lit-html';
 import '@conversionxl/cxl-ui/src/components/cxl-app-layout.js';
 import '@conversionxl/cxl-ui/src/components/cxl-marketing-nav.js';
 import '@conversionxl/cxl-ui/src/components/cxl-playbook-accordion.js';
 import '@conversionxl/cxl-ui/src/components/cxl-save-favorite.js';
 import '@vaadin/vaadin-button';
+
+import { html } from 'lit-html';
+
 import { CXLMarketingNav } from '../cxl-marketing-nav.stories';
 import { CXLPlaybookAccordion } from '../cxl-vaadin-accordion.stories';
 

--- a/packages/storybook/cxl-ui/cxl-app-layout/layout=2c-r.stories.js
+++ b/packages/storybook/cxl-ui/cxl-app-layout/layout=2c-r.stories.js
@@ -1,7 +1,9 @@
-import { html } from 'lit-html';
-import { withKnobs, boolean } from '@storybook/addon-knobs';
 import '@conversionxl/cxl-ui/src/components/cxl-app-layout.js';
 import '@conversionxl/cxl-ui/src/components/cxl-marketing-nav.js';
+
+import { boolean, withKnobs } from '@storybook/addon-knobs';
+import { html } from 'lit-html';
+
 import { CXLMarketingNav } from '../cxl-marketing-nav.stories';
 
 export default {

--- a/packages/storybook/cxl-ui/cxl-card/[theme=cxl-testimonial].stories.js
+++ b/packages/storybook/cxl-ui/cxl-card/[theme=cxl-testimonial].stories.js
@@ -1,6 +1,7 @@
-import { html } from 'lit-html';
 import '@conversionxl/cxl-ui/src/components/cxl-card.js';
 import '@conversionxl/cxl-lumo-styles';
+
+import { html } from 'lit-html';
 
 export default {
   title: 'CXL UI/cxl-card',

--- a/packages/storybook/cxl-ui/cxl-marketing-nav.stories.js
+++ b/packages/storybook/cxl-ui/cxl-marketing-nav.stories.js
@@ -1,7 +1,9 @@
-import { html } from 'lit-html';
-import { useEffect } from '@storybook/client-api';
 import '@conversionxl/cxl-ui/src/components/cxl-marketing-nav.js';
+
 import { Headroom } from '@conversionxl/cxl-ui';
+import { useEffect } from '@storybook/client-api';
+import { html } from 'lit-html';
+
 import contextMenuItems from './cxl-marketing-nav.data.json';
 
 export default {

--- a/packages/storybook/cxl-ui/cxl-paywall.stories.js
+++ b/packages/storybook/cxl-ui/cxl-paywall.stories.js
@@ -1,7 +1,8 @@
-import { html } from 'lit-html';
 import '../../cxl-ui/src/components/cxl-paywall';
-import { loremIpsum } from 'lorem-ipsum';
+
+import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html';
+import { loremIpsum } from 'lorem-ipsum';
 
 const content = loremIpsum({ count: 10, format: 'html', units: 'paragraphs' });
 

--- a/packages/storybook/cxl-ui/cxl-paywall/cxl-paywall-layout=2c-l.stories.js
+++ b/packages/storybook/cxl-ui/cxl-paywall/cxl-paywall-layout=2c-l.stories.js
@@ -1,6 +1,8 @@
+import '../../../cxl-ui/src/components/cxl-paywall';
+
 import { boolean, withKnobs } from '@storybook/addon-knobs';
 import { html } from 'lit-html';
-import '../../../cxl-ui/src/components/cxl-paywall';
+
 import { CXLMarketingNav } from '../cxl-marketing-nav.stories';
 import { CXLStarRating } from '../cxl-star-rating.stories';
 import { CXLPlaybookAccordion } from '../cxl-vaadin-accordion/cxl-playbook-accordion.story';

--- a/packages/storybook/cxl-ui/cxl-star-rating.stories.js
+++ b/packages/storybook/cxl-ui/cxl-star-rating.stories.js
@@ -1,5 +1,6 @@
-import { html } from 'lit-html';
 import '@conversionxl/cxl-ui/src/components/cxl-star-rating.js';
+
+import { html } from 'lit-html';
 
 /**
  * 2021-01-14

--- a/packages/storybook/cxl-ui/cxl-tabs-slider/cxl-tabs-slider.stories.js
+++ b/packages/storybook/cxl-ui/cxl-tabs-slider/cxl-tabs-slider.stories.js
@@ -1,6 +1,8 @@
 import '@conversionxl/cxl-ui/src/components/cxl-card';
 import '@conversionxl/cxl-ui/src/components/cxl-tabs-slider';
+
 import { html } from 'lit-html';
+
 import { CXLTestimonial } from '../cxl-card/[theme=cxl-testimonial].stories';
 import archiveData from '../cxl-vaadin-accordion/theme=cxl-archive.data.json';
 

--- a/packages/storybook/cxl-ui/cxl-vaadin-accordion.stories.js
+++ b/packages/storybook/cxl-ui/cxl-vaadin-accordion.stories.js
@@ -1,8 +1,8 @@
 import { CXLVaadinAccordionThemeArchive } from './cxl-vaadin-accordion/cxl-accordion-card.story';
+import { CXLHubsAndPlaybooks } from './cxl-vaadin-accordion/cxl-hubs-and-playbooks.story';
 import { CXLPlaybookAccordion } from './cxl-vaadin-accordion/cxl-playbook-accordion.story';
 import { CXLVaadinAccordionThemeFaq } from './cxl-vaadin-accordion/theme=cxl-faq.story';
 import { CXLVaadinAccordionThemeMinidegreeTrack } from './cxl-vaadin-accordion/theme=cxl-minidegree-track.story';
-import { CXLHubsAndPlaybooks } from './cxl-vaadin-accordion/cxl-hubs-and-playbooks.story';
 
 export default {
   title: 'CXL UI/cxl-vaadin-accordion',
@@ -22,9 +22,9 @@ CXLVaadinAccordionThemeMinidegreeTrack.storyName = '[theme=cxl-minidegree-track]
 CXLHubsAndPlaybooks.storyName = 'cxl-hubs-and-playbooks';
 
 export {
+  CXLHubsAndPlaybooks,
   CXLPlaybookAccordion,
   CXLVaadinAccordionThemeArchive,
   CXLVaadinAccordionThemeFaq,
   CXLVaadinAccordionThemeMinidegreeTrack,
-  CXLHubsAndPlaybooks,
 };

--- a/packages/storybook/cxl-ui/cxl-vaadin-accordion/cxl-accordion-card.story.js
+++ b/packages/storybook/cxl-ui/cxl-vaadin-accordion/cxl-accordion-card.story.js
@@ -1,8 +1,10 @@
-import { html } from 'lit-html';
-import { unsafeHTML } from 'lit-html/directives/unsafe-html';
 import '@conversionxl/cxl-ui/src/components/cxl-vaadin-accordion.js';
 import '@conversionxl/cxl-ui/src/components/cxl-accordion-card.js';
 import '@conversionxl/cxl-ui/src/components/cxl-save-favorite.js';
+
+import { html } from 'lit-html';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html';
+
 import archiveData from './theme=cxl-archive.data.json';
 
 export const CXLVaadinAccordionThemeArchive = () => {

--- a/packages/storybook/cxl-ui/cxl-vaadin-accordion/cxl-hubs-and-playbooks.story.js
+++ b/packages/storybook/cxl-ui/cxl-vaadin-accordion/cxl-hubs-and-playbooks.story.js
@@ -1,11 +1,13 @@
-import { html } from 'lit-html';
 import '@conversionxl/cxl-ui/src/components/cxl-vaadin-accordion.js';
+
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { registerStyles, css } from '@vaadin/vaadin-themable-mixin/register-styles';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles';
+import { html } from 'lit-html';
+
+import hubsData from './hub-card.data.json';
 import CxlHubCardDisplay from './partials/cxl-hub-card-display';
 import CxlSingleversionCardDisplay from './partials/cxl-singleversion-card-display';
 import playbookData from './playbook-card.data.json';
-import hubsData from './hub-card.data.json';
 
 registerStyles(
   'cxl-accordion-card',

--- a/packages/storybook/cxl-ui/cxl-vaadin-accordion/cxl-playbook-accordion.story.js
+++ b/packages/storybook/cxl-ui/cxl-vaadin-accordion/cxl-playbook-accordion.story.js
@@ -1,5 +1,6 @@
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html';
+
 import playbookStepData from './cxl-playbook-accordion.data.json';
 
 export const CXLPlaybookAccordion = ({ FeedbackButtonLabel, PlaybookId }) => html`

--- a/packages/storybook/cxl-ui/cxl-vaadin-accordion/theme=cxl-faq.story.js
+++ b/packages/storybook/cxl-ui/cxl-vaadin-accordion/theme=cxl-faq.story.js
@@ -1,6 +1,8 @@
+import '@conversionxl/cxl-ui/src/components/cxl-vaadin-accordion.js';
+
 import { html } from 'lit-html';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html';
-import '@conversionxl/cxl-ui/src/components/cxl-vaadin-accordion.js';
+
 import faqData from './theme=cxl-faq.data.json';
 
 export const CXLVaadinAccordionThemeFaq = () => html`

--- a/packages/storybook/cxl-ui/cxl-vaadin-accordion/theme=cxl-minidegree-track.story.js
+++ b/packages/storybook/cxl-ui/cxl-vaadin-accordion/theme=cxl-minidegree-track.story.js
@@ -1,5 +1,6 @@
-import { html } from 'lit-html';
 import '@conversionxl/cxl-ui/src/components/cxl-vaadin-accordion.js';
+
+import { html } from 'lit-html';
 
 export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
   <style>

--- a/packages/test-helpers/keys.js
+++ b/packages/test-helpers/keys.js
@@ -14,7 +14,7 @@ export function keyboardEventFor(type, keyCode, modifiers = [], key) {
     bubbles: true,
     cancelable: true,
     // Allow event to go outside a ShadowRoot.
-    composed: true
+    composed: true,
   });
 
   event.keyCode = keyCode;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2006,7 +2006,7 @@
   version "1.0.1"
   resolved "https://npm.cxl.co/@conversionxl%2fnormalize-wheel/-/normalize-wheel-1.0.1.tgz#56a8181fcb9b10f73806e81f6121255849e2d424"
   integrity sha512-gmQYGD4K6eKycJz8BFNVIZWruUmXpooOMS8dfWS8FYP16gZ9kTuDknTW4Zq213DCO8AxNdHRN71j0CZoLdwv5Q==
-  
+
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
@@ -8822,6 +8822,11 @@ eslint-plugin-lit@^1.2.2:
     parse5 "^6.0.1"
     parse5-htmlparser2-tree-adapter "^6.0.1"
     requireindex "^1.2.0"
+
+eslint-plugin-simple-import-sort@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz#a1dad262f46d2184a90095a60c66fef74727f0f8"
+  integrity sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==
 
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
This adds `prettier-plugin-organize-imports` (https://github.com/simonhaenisch/prettier-plugin-organize-imports) which handles sorting of imports automatically.