### PR TITLE
fix(cxl-lumo-styles): add CSS `top` property to `headroom`

### DIFF
--- a/packages/cxl-lumo-styles/scss/global.scss
+++ b/packages/cxl-lumo-styles/scss/global.scss
@@ -79,6 +79,7 @@ ul {
  * headroom.js
  */
 .headroom {
+  top: var(--wp-admin--admin-bar--height, 0);
   transition: transform 200ms linear;
 
   &--pinned {


### PR DESCRIPTION
Issue: #196 
Inspired by:
- [WordPress/wporg-news-2021@`20f1bde` (#178)](https://github.com/WordPress/wporg-news-2021/pull/178/commits/20f1bde806e27cace085d8a53709e6d7e203eb6f)
- [WordPress/wporg-news-2021@`3106b25` (#178)](https://github.com/WordPress/wporg-news-2021/pull/178/commits/3106b259751b48321145f9bbf82e342b8ea2d7a8)
- https://github.com/WordPress/WordPress/commit/e32d9ec5226ec01e4a2de3cec4a4da0582d1d52c