### PR TITLE
fix(cxl-ui): action bar position

### DIFF
--- a/packages/cxl-ui/scss/cxl-app-layout/_layout.scss
+++ b/packages/cxl-ui/scss/cxl-app-layout/_layout.scss
@@ -39,7 +39,7 @@ $toggle-icon: "lumo:angle-right";
     }
 
     > [name="action-bar"] {
-      position: sticky;
+      position: absolute;
       right: 0;
       bottom: 0;
       left: 0;


### PR DESCRIPTION
Fix the position of the action bar so that it is along the bottom of the viewport.

![image](https://user-images.githubusercontent.com/147228/218261249-85ac038d-5463-4ae5-b45e-e2e968279989.png)

Delete `.entry-content` element from any lesson content.