### PR TITLE
anoblet/fix/storybook-definition

### DIFF
--- a/packages/storybook/cxl-ui/cxl-like-or-dislike/[theme=default].stories.js
+++ b/packages/storybook/cxl-ui/cxl-like-or-dislike/[theme=default].stories.js
@@ -1,9 +1,9 @@
-import { CXLLikeOrDislikeElement } from '@conversionxl/cxl-ui';
+import '@conversionxl/cxl-ui/src/components/cxl-like-or-dislike.js';
 import { html } from 'lit-html';
 
 export default {
   title: 'CXL UI/cxl-like-or-dislike',
-  component: CXLLikeOrDislikeElement,
+  component: 'cxl-like-or-dislike',
 };
 
 const Template = ({ apiUrl, postType, postId, userId, upVotes }) => html`

--- a/packages/storybook/cxl-ui/cxl-save-favorite/[theme=default].stories.js
+++ b/packages/storybook/cxl-ui/cxl-save-favorite/[theme=default].stories.js
@@ -1,9 +1,9 @@
-import { CXLSaveFavoriteElement } from '@conversionxl/cxl-ui';
+import '@conversionxl/cxl-ui/src/components/cxl-save-favorite.js';
 import { html } from 'lit-html';
 
 export default {
   title: 'CXL UI/cxl-save-favorite',
-  component: CXLSaveFavoriteElement,
+  component: 'cxl-save-favorite',
 };
 
 const Template = ({ apiUrl, postType, postId, userId, isCardVersion, selected }) => html`


### PR DESCRIPTION
When syncing with master I'm running into this error:

![localhost_6006_](https://user-images.githubusercontent.com/7674171/171416476-97f3a7be-d8e6-45bb-a930-2fb07bfb427e.png)

As opposed to React, Web Components don't use the `component` field (https://storybook.js.org/docs/web-components/writing-stories/introduction).

The field can either be omitted or set to a string.


