### PR TITLE
chore(cxl-lumo-styles,cxl-ui): v1.2.0

### DIFF
--- a/packages/cxl-lumo-styles/package.json
+++ b/packages/cxl-lumo-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conversionxl/cxl-lumo-styles",
-  "version": "1.1.0-alpha.10",
+  "version": "1.2.0",
   "author": "CXL <leho@cxl.com>",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "src/index.js",

--- a/packages/cxl-ui/package.json
+++ b/packages/cxl-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conversionxl/cxl-ui",
-  "version": "1.1.0-alpha.10",
+  "version": "1.2.0",
   "author": "CXL <leho@cxl.com>",
   "license": "SEE LICENSE IN LICENSE",
   "main": "src/index.js",
@@ -10,7 +10,7 @@
     "directory": "packages/cxl-ui"
   },
   "dependencies": {
-    "@conversionxl/cxl-lumo-styles": "^1.1.0-alpha.2",
+    "@conversionxl/cxl-lumo-styles": "^1.2.0",
     "@conversionxl/normalize-wheel": "^1.0.1",
     "@cwmr/iron-star-rating": "github:conversionxl/iron-star-rating",
     "@pika/pack": "^0.5.0",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -8,8 +8,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@conversionxl/cxl-lumo-styles": "^1.1.0-alpha.10",
-    "@conversionxl/cxl-ui": "^1.1.0-alpha.10",
+    "@conversionxl/cxl-lumo-styles": "^1.2.0",
+    "@conversionxl/cxl-ui": "^1.2.0",
     "@storybook/addon-controls": "^6.3.12",
     "@storybook/addon-knobs": "^6.3.1",
     "@storybook/addon-viewport": "^6.3.12",


### PR DESCRIPTION
Versions: 1.1.0, 1.1.1 and 1.1.2 which are published in registry are missing from the repository due the lack of possibility to push directly to `master` branch and @pawelkmpt mistake.

Trying to work it around by PRs would take too much time.

* https://npm.cxl.co/-/web/detail/@conversionxl/cxl-ui/v/1.1.1
* https://npm.cxl.co/-/web/detail/@conversionxl/cxl-ui/v/1.1.2
* https://npm.cxl.co/-/web/detail/@conversionxl/cxl-lumo-styles/v/1.1.2