### PR TITLE
anoblet/feat/vaadin-icon

### DIFF
--- a/packages/cxl-lumo-styles/package.json
+++ b/packages/cxl-lumo-styles/package.json
@@ -10,7 +10,6 @@
     "directory": "packages/cxl-lumo-styles"
   },
   "dependencies": {
-    "@polymer/iron-iconset-svg": "^3.0.1",
     "@vaadin/polymer-legacy-adapter": "^23.3.0",
     "@vaadin/vaadin-lumo-styles": "^23.3.0",
     "@vaadin/vaadin-themable-mixin": "^23.3.0"

--- a/packages/cxl-lumo-styles/scss/global.scss
+++ b/packages/cxl-lumo-styles/scss/global.scss
@@ -76,7 +76,7 @@ a {
   }
 
   // Icon alignment.
-  iron-icon + & {
+  vaadin-icon + & {
     vertical-align: middle;
   }
 }
@@ -157,7 +157,7 @@ ul {
   @include mixins.wrap();
 }
 
-// Center align the `<iron-icon>` wrapped in `<vaadin-button>`
+// Center align the `<vaadin-icon>` wrapped in `<vaadin-button>`
 vaadin-notification-card vaadin-button[theme~="icon"]:not([theme~="tertiary-inline"]) {
   flex: none;
 }

--- a/packages/cxl-lumo-styles/src/color.js
+++ b/packages/cxl-lumo-styles/src/color.js
@@ -1,10 +1,6 @@
-import '@vaadin/vaadin-lumo-styles/color.js';
-import styles from './styles/color-css.js';
+import { color } from '@vaadin/vaadin-lumo-styles';
+import { registerGlobalStyles } from './utils.js';
+import colorStyles from './styles/color-css.js';
 
-const $template = document.createElement('template');
-$template.innerHTML = `
-  <custom-style>
-    <style id="cxl-lumo-styles-color" include="lumo-color">${styles}</style>
-  </custom-style>
-`;
-document.head.appendChild($template.content);
+registerGlobalStyles(color, { moduleId: 'vaadin-lumo-styles-color' });
+registerGlobalStyles(colorStyles, { moduleId: 'cxl-lumo-styles-color' });

--- a/packages/cxl-lumo-styles/src/icons.js
+++ b/packages/cxl-lumo-styles/src/icons.js
@@ -1,13 +1,14 @@
 import { css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import { registerGlobalStyles } from './utils.js';
 import '@vaadin/vaadin-lumo-styles/font-icons.js';
-import '@vaadin/vaadin-lumo-styles/icons.js';
 import '@vaadin/vaadin-lumo-styles/sizing.js';
-import '@polymer/iron-iconset-svg/iron-iconset-svg.js';
+
+// @todo Vaadin 24: `import '@vaadin/vaadin-lumo-styles/vaadin-icons.js'`.
+import '@vaadin/vaadin-lumo-styles/vaadin-iconset.js';
 
 registerGlobalStyles(
   css`
-    iron-icon[icon='vaadin:play-circle-o'] {
+    vaadin-icon[icon='vaadin:play-circle-o'] {
       clip-path: polygon(50% 0, 100% 0, 100% 100%, 0% 100%, 0% 75%); /* "In-progress". */
     }
   `,
@@ -24,12 +25,12 @@ const $documentContainer = document.createElement('template');
  * 1. `conversionxl/vaadin-icons` fork has a custom `gulpfile.js`, clone, install deps.
  * 2. vaadin-icons/gulpfile.js: modify `const cxlVaadinIconset`
  * 3. vaadin-icons: run `npx gulp icons iconfont`
- * 4. iron-iconset-svg[name="vaadin"]: copy-paste vaadin-icons/iconset.html `<g>` elements
- * 5. iron-iconset-svg[name="vaadin"]: copy-paste vaadin-icons/vaadin-icons.woff2 base64 encoding
+ * 4. vaadin-iconset[name="vaadin"]: copy-paste vaadin-icons/iconset.html `<g>` elements
+ * 5. vaadin-iconset[name="vaadin"]: copy-paste vaadin-icons/vaadin-icons.woff2 base64 encoding
  * 6. style#cxl-lumo-styles-vaadin-icons: add / change CSS custom properties, get unicode values from `gulp iconfont` task output
  */
 $documentContainer.innerHTML = `
-  <iron-iconset-svg size="25" name="cxl">
+  <vaadin-iconset size="25" name="cxl">
     <svg>
       <defs>
         <g id="logo" width="60" height="24" viewBox="0 0 60 24">
@@ -52,8 +53,8 @@ $documentContainer.innerHTML = `
         </g>
       </defs>
     </svg>
-  </iron-iconset-svg>
-  <iron-iconset-svg size="16" name="vaadin">
+  </vaadin-iconset>
+  <vaadin-iconset size="16" name="vaadin">
     <svg>
       <defs>
         <g id="check-circle"><path d="M8 0c-4.4 0-8 3.6-8 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zM7.1 11.7l-4.2-4.1 1.4-1.4 2.7 2.7 5-4.9 1.4 1.4-6.3 6.3z"/></g>
@@ -69,7 +70,7 @@ $documentContainer.innerHTML = `
         <g id="thumbs-up-o"><path d="M16 7.1c0-1.5-1.4-2.1-2.2-2.1h-2.2c0.4-1 0.7-2.2 0.5-3.1-0.5-1.8-2-1.9-2.5-1.9h-0.1c-0.4 0-0.6 0.2-0.8 0.5l-1 2.8-2.7 2.7h-5v9h5v-1c0.2 0 0.7 0.3 1.2 0.6 1.2 0.6 2.9 1.5 4.5 1.5 2.4 0 3.2-0.3 3.8-1.3 0.3-0.6 0.3-1.1 0.3-1.4 0.2-0.2 0.5-0.5 0.6-1s0.1-0.8 0-1.1c0.2-0.3 0.4-0.7 0.5-1.3 0-0.5-0.1-0.9-0.2-1.2 0.1-0.4 0.3-0.9 0.3-1.7zM2.5 13.5c-0.6 0-1-0.4-1-1s0.4-1 1-1 1 0.4 1 1c0 0.6-0.4 1-1 1zM14.7 9.1c0 0 0.2 0.2 0.2 0.7 0 0.6-0.4 0.9-0.4 0.9l-0.3 0.3 0.2 0.3c0 0 0.2 0.3 0 0.7-0.1 0.4-0.5 0.7-0.5 0.7l-0.3 0.3 0.2 0.4c0 0 0.2 0.4-0.1 0.9-0.2 0.4-0.4 0.7-2.9 0.7-1.4 0-3-0.8-4.1-1.4-0.8-0.4-1.3-0.6-1.7-0.6v0-6h0.1c0.2 0 0.4-0.1 0.6-0.2l2.8-2.8c0.1-0.1 0.1-0.2 0.2-0.3l1-2.7c0.5 0 1.2 0.2 1.4 1.1 0.1 0.6-0.1 1.6-0.6 2.8-0.1 0.3-0.1 0.5 0.1 0.8 0.1 0.2 0.4 0.3 0.7 0.3h2.5c0.1 0 1.2 0.2 1.2 1.1 0 0.8-0.3 1.2-0.3 1.2l-0.3 0.4 0.3 0.4z"/></g>
       </defs>
     </svg>
-  </iron-iconset-svg>
+  </vaadin-iconset>
   <style id="cxl-lumo-styles-vaadin-icons">
     @font-face {
       font-family: vaadin-icons;

--- a/packages/cxl-lumo-styles/src/typography.js
+++ b/packages/cxl-lumo-styles/src/typography.js
@@ -1,10 +1,6 @@
-import '@vaadin/vaadin-lumo-styles/typography.js';
-import styles from './styles/typography-css.js';
+import { typography } from '@vaadin/vaadin-lumo-styles';
+import { registerGlobalStyles } from './utils.js';
+import typographyStyles from './styles/typography-css.js';
 
-const $template = document.createElement('template');
-$template.innerHTML = `
-  <custom-style>
-    <style id="cxl-lumo-styles-typography" include="lumo-typography">${styles}</style>
-  </custom-style>
-`;
-document.head.appendChild($template.content);
+registerGlobalStyles(typography, { moduleId: 'vaadin-lumo-styles-typography' });
+registerGlobalStyles(typographyStyles, { moduleId: 'cxl-lumo-styles-typography' });

--- a/packages/cxl-lumo-styles/src/utils.js
+++ b/packages/cxl-lumo-styles/src/utils.js
@@ -1,9 +1,17 @@
 /**
+ * Polymer legacy adapter is required for at least:
+ * template-renderer.js: Adds declarative <template> APIs with Polymer binding support to Vaadin components.
+ *
+ * @see https://github.com/vaadin/web-components/issues/2642
+ * @see https://github.com/vaadin/web-components/tree/23.3/packages/polymer-legacy-adapter
  * @see https://github.com/vaadin/web-components/blob/23.1/packages/vaadin-themable-mixin/vaadin-themable-mixin.js#L36-L58
+ */
+import '@vaadin/polymer-legacy-adapter/template-renderer';
+
+/**
+ * @see https://github.com/vaadin/web-components/issues/2642
  * @todo Align with Vaadin v23.1+.
  */
-import '@vaadin/polymer-legacy-adapter';
-
 let moduleIdIndex = 0;
 const styleMap = {};
 

--- a/packages/cxl-ui/package.json
+++ b/packages/cxl-ui/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@conversionxl/cxl-lumo-styles": "^1.2.0",
     "@conversionxl/normalize-wheel": "^1.0.1",
-    "@cwmr/iron-star-rating": "github:conversionxl/iron-star-rating",
     "@pika/pack": "^0.5.0",
     "@pika/plugin-build-web": "^0.9.2",
     "@pika/plugin-bundle-web": "^0.9.2",

--- a/packages/cxl-ui/scss/_mixins.scss
+++ b/packages/cxl-ui/scss/_mixins.scss
@@ -3,8 +3,8 @@
   align-items: flex-start;
 
   [icon] {
-    --iron-icon-width: var(--lumo-icon-size-s);
-    --iron-icon-height: var(--iron-icon-width);
+    --vaadin-icon-width: var(--lumo-icon-size-s);
+    --vaadin-icon-height: var(--vaadin-icon-width);
 
     flex-shrink: 0;
     margin-right: var(--lumo-space-s);

--- a/packages/cxl-ui/scss/cxl-like-or-dislike.scss
+++ b/packages/cxl-ui/scss/cxl-like-or-dislike.scss
@@ -16,7 +16,7 @@
   }
 
   .vote {
-    iron-icon {
+    vaadin-icon {
       width: var(--lumo-icon-size-s);
       height: var(--lumo-icon-size-s);
       font-size: var(--lumo-font-size-s);

--- a/packages/cxl-ui/scss/cxl-marketing-nav.scss
+++ b/packages/cxl-ui/scss/cxl-marketing-nav.scss
@@ -28,8 +28,8 @@
   }
 
   .menu-item-menu-toggle {
-    &[selected] iron-icon:first-child,
-    &:not([selected]) iron-icon + iron-icon {
+    &[selected] vaadin-icon:first-child,
+    &:not([selected]) vaadin-icon + vaadin-icon {
       display: none;
     }
   }

--- a/packages/cxl-ui/scss/cxl-save-favorite.scss
+++ b/packages/cxl-ui/scss/cxl-save-favorite.scss
@@ -1,7 +1,7 @@
 $star-active-color: #fdd835;
 $star-inactive-color: #eee;
 
-:host([selected]) iron-icon {
+:host([selected]) vaadin-icon {
   color: $star-active-color;
 }
 
@@ -9,7 +9,7 @@ $star-inactive-color: #eee;
   margin-left: var(--lumo-space-xs);
 }
 
-iron-icon {
+vaadin-icon {
   color: $star-inactive-color;
 
   &:hover {
@@ -26,7 +26,7 @@ a {
     cursor: pointer;
   }
 
-  &:hover iron-icon {
+  &:hover vaadin-icon {
     color: $star-active-color;
   }
 }

--- a/packages/cxl-ui/scss/global/cxl-marketing-nav.scss
+++ b/packages/cxl-ui/scss/global/cxl-marketing-nav.scss
@@ -108,7 +108,7 @@ vaadin-context-menu-list-box {
   background-color: transparent;
 }
 
-.context-menu-item-back-button iron-icon {
+.context-menu-item-back-button vaadin-icon {
   margin-left: calc(var(--lumo-icon-size-m) / 4 * -1);
 }
 

--- a/packages/cxl-ui/scss/global/cxl-vaadin-accordion.scss
+++ b/packages/cxl-ui/scss/global/cxl-vaadin-accordion.scss
@@ -6,9 +6,9 @@ cxl-vaadin-accordion {
    * Theme "cxl-accordion-card".
    */
   &[theme~="cxl-accordion-card"] {
-    iron-icon {
-      --iron-icon-height: var(--lumo-icon-size-s);
-      --iron-icon-width: var(--iron-icon-height);
+    vaadin-icon {
+      --vaadin-icon-height: var(--lumo-icon-size-s);
+      --vaadin-icon-width: var(--vaadin-icon-height);
     }
 
     p {
@@ -24,7 +24,7 @@ cxl-vaadin-accordion {
     }
 
     .entry-byline {
-      display: flex; // iron-icon vs text alignment
+      display: flex; // vaadin-icon vs text alignment
       flex-basis: 100%;
       flex-wrap: wrap;
       margin: var(--lumo-space-s) 0;
@@ -150,9 +150,9 @@ cxl-vaadin-accordion {
     column-rule: 1px solid var(--lumo-shade-10pct);
     column-width: calc(var(--cxl-wrap-width) / 4);
 
-    iron-icon {
-      --iron-icon-height: var(--lumo-icon-size-s);
-      --iron-icon-width: var(--iron-icon-height);
+    vaadin-icon {
+      --vaadin-icon-height: var(--lumo-icon-size-s);
+      --vaadin-icon-width: var(--vaadin-icon-height);
     }
 
     p {
@@ -177,7 +177,7 @@ cxl-vaadin-accordion {
     }
 
     .entry-byline {
-      display: flex; // iron-icon vs text alignment
+      display: flex; // vaadin-icon vs text alignment
       flex-basis: 100%;
       flex-direction: column;
       flex-wrap: wrap;

--- a/packages/cxl-ui/src/components/cxl-app-layout.js
+++ b/packages/cxl-ui/src/components/cxl-app-layout.js
@@ -81,7 +81,7 @@ export class CXLAppLayoutElement extends LitElement {
             this.asideOpened = !this.asideOpened;
           }}"
         >
-          <iron-icon icon="lumo:angle-right"></iron-icon>
+          <vaadin-icon icon="lumo:angle-right"></vaadin-icon>
         </vaadin-button>
         <slot name="sidebar"></slot>
       </aside>

--- a/packages/cxl-ui/src/components/cxl-like-or-dislike.js
+++ b/packages/cxl-ui/src/components/cxl-like-or-dislike.js
@@ -177,10 +177,10 @@ export class CXLLikeOrDislikeElement extends LitElement {
     return html`<div>
       <div counter>${this.upVotes} Vote${plural}</div>
       <div class="vote" @click="${this._upVote}" up>
-        <iron-icon icon="vaadin:thumbs-up-o"></iron-icon><span>Upvote${d1}</span>
+        <vaadin-icon icon="vaadin:thumbs-up-o"></vaadin-icon><span>Upvote${d1}</span>
       </div>
       <div class="vote" @click="${this._downVote}" down>
-        <iron-icon icon="vaadin:thumbs-down-o"></iron-icon><span>Downvote${d2}</span>
+        <vaadin-icon icon="vaadin:thumbs-down-o"></vaadin-icon><span>Downvote${d2}</span>
       </div>
     </div>`;
   }

--- a/packages/cxl-ui/src/components/cxl-marketing-nav.js
+++ b/packages/cxl-ui/src/components/cxl-marketing-nav.js
@@ -74,7 +74,10 @@ export class CXLMarketingNavElement extends LitElement {
       >
         <vaadin-tab class="menu-item menu-item-logo" theme="cxl-marketing-nav">
           <a href="https://conversionxl.com"
-            ><iron-icon icon="cxl:logo" style="width: var(--lumo-icon-size-xl, 48px);"></iron-icon
+            ><vaadin-icon
+              icon="cxl:logo"
+              style="width: var(--lumo-icon-size-xl, 48px);"
+            ></vaadin-icon
           ></a>
         </vaadin-tab>
         <vaadin-tab
@@ -83,8 +86,8 @@ export class CXLMarketingNavElement extends LitElement {
           ?hidden="${this.minimal}"
         >
           <a
-            ><iron-icon icon="lumo:search"></iron-icon> Search
-            <iron-icon icon="lumo:dropdown"></iron-icon
+            ><vaadin-icon icon="lumo:search"></vaadin-icon> Search
+            <vaadin-icon icon="lumo:dropdown"></vaadin-icon
           ></a>
           <vaadin-context-menu
             close-on="outside-click"
@@ -99,7 +102,8 @@ export class CXLMarketingNavElement extends LitElement {
           @click=${this._toggleMobileMenu}
         >
           <a
-            >Menu <iron-icon icon="lumo:menu"></iron-icon><iron-icon icon="lumo:cross"></iron-icon
+            >Menu <vaadin-icon icon="lumo:menu"></vaadin-icon
+            ><vaadin-icon icon="lumo:cross"></vaadin-icon
           ></a>
         </vaadin-tab>
       </vaadin-tabs>
@@ -322,7 +326,7 @@ export class CXLMarketingNavElement extends LitElement {
         const backBtn = document.createElement('vaadin-button');
 
         backBtn.classList.add('context-menu-item-back-button');
-        backBtn.innerHTML = '<iron-icon icon="lumo:angle-left"></iron-icon> Back';
+        backBtn.innerHTML = '<vaadin-icon icon="lumo:angle-left"></vaadin-icon> Back';
 
         menuItemBack.classList.add('back-button-menu-item');
         menuItemBack.appendChild(backBtn);

--- a/packages/cxl-ui/src/components/cxl-save-favorite.js
+++ b/packages/cxl-ui/src/components/cxl-save-favorite.js
@@ -9,8 +9,8 @@ export class CXLSaveFavoriteElement extends LitElement {
   @query('a')
   anchor;
 
-  @query('a > iron-icon')
-  ironIcon;
+  @query('a > vaadin-icon')
+  vaadinIcon;
 
   /**
    * Is post currently in the "saved" state
@@ -75,7 +75,7 @@ export class CXLSaveFavoriteElement extends LitElement {
   async _anchorClicked(event) {
     event.stopPropagation();
 
-    this.ironIcon.classList.toggle('selected');
+    this.vaadinIcon.classList.toggle('selected');
     this.selected = !this.selected;
 
     await this.sendToApi();
@@ -89,7 +89,7 @@ export class CXLSaveFavoriteElement extends LitElement {
     return html`
       <div>
         <a @click=${this._anchorClicked} title="${text}">
-          <iron-icon icon="vaadin:star"></iron-icon>
+          <vaadin-icon icon="vaadin:star"></vaadin-icon>
           ${afterStar}
         </a>
       </div>

--- a/packages/cxl-ui/src/components/cxl-star-rating.js
+++ b/packages/cxl-ui/src/components/cxl-star-rating.js
@@ -18,16 +18,16 @@ export class CXLStarRatingElement extends LitElement {
       --mdc-icon-size: var(--mwc-star-rating-size, 24px);
     }
 
-    :host iron-icon:hover,
-    :host iron-icon:hover ~ iron-icon {
+    :host vaadin-icon:hover,
+    :host vaadin-icon:hover ~ vaadin-icon {
       color: var(--mwc-star-rating-text-hover-color, #ffeb3b) !important;
     }
 
-    iron-icon {
+    vaadin-icon {
       float: right;
     }
 
-    iron-icon.whole {
+    vaadin-icon.whole {
       -webkit-clip-path: inset(0 0 0 50%);
       -moz-clip-path: inset(0 0 0 50%);
       -ms-clip-path: inset(0 0 0 50%);
@@ -38,7 +38,7 @@ export class CXLStarRatingElement extends LitElement {
       margin-right: calc(var(--mdc-icon-size) * -1);
     }
 
-    iron-icon.half {
+    vaadin-icon.half {
       -webkit-clip-path: inset(0 50% 0 0);
       -moz-clip-path: inset(0 50% 0 0);
       -ms-clip-path: inset(0 50% 0 0);
@@ -47,8 +47,8 @@ export class CXLStarRatingElement extends LitElement {
       position: relative;
     }
 
-    iron-icon[selected],
-    iron-icon[selected] ~ iron-icon {
+    vaadin-icon[selected],
+    vaadin-icon[selected] ~ vaadin-icon {
       color: var(--mwc-star-rating-text-selected-color, #fdd835);
     }
   `;
@@ -86,13 +86,13 @@ export class CXLStarRatingElement extends LitElement {
       ${this._ratings.map(
         (item) =>
           html`
-            <iron-icon
+            <vaadin-icon
               class="${item.class}"
               icon=${this.icon}
               value="${item.value}"
               ?selected="${item.selected}"
               @click="${(e) => this._starClicked(e, item.value)}"
-            ></iron-icon>
+            ></vaadin-icon>
           `
       )}
     `;

--- a/packages/storybook/cxl-lumo-styles/icons-preview.js
+++ b/packages/storybook/cxl-lumo-styles/icons-preview.js
@@ -1,7 +1,8 @@
 /**
  * @see https://github.com/vaadin/docs/blob/838707b08368ca4a225e2e12840ff980b5ecc7ea/frontend/demo/foundation/icons-preview.ts
  */
-import { LitElement, html, customElement, property } from 'lit-element';
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
 import { registerGlobalStyles } from '@conversionxl/cxl-lumo-styles/src/utils';
 
@@ -39,7 +40,7 @@ const iconsPreviewStyles = css`
   }
 
   .cxl-icon-preview svg,
-  .cxl-icon-preview iron-icon {
+  .cxl-icon-preview vaadin-icon {
     display: inline-block !important;
     width: 48px !important;
     height: 48px !important;
@@ -96,7 +97,7 @@ export class IconsPreview extends LitElement {
 
   _getIcons() {
     const iconSetName = this.name;
-    const iconSets = document.querySelectorAll('iron-iconset-svg');
+    const iconSets = document.querySelectorAll('vaadin-iconset');
 
     const iconSetFiltered = [...iconSets].filter(
       (iconSet) => iconSet.getAttribute('name') === iconSetName
@@ -106,7 +107,15 @@ export class IconsPreview extends LitElement {
       return null;
     }
 
-    return iconSetFiltered[0].getIconNames();
+    const icons = iconSetFiltered[0].__createIconMap();
+
+    /* eslint-disable func-names */
+    const names = Object.keys(icons).map(function (n) {
+      return `${this.name}:${n}`;
+    }, this);
+    /* eslint-enable func-names */
+
+    return names;
   }
 
   _searchInput(e) {
@@ -151,14 +160,13 @@ export class IconsPreview extends LitElement {
         title = `Since Vaadin 21, '${name}' is deprecated. Please use '${DEPRECATED_ICONS[name]}' instead.`;
       }
 
-      iconTemplate = html`
-        <div
-          class="cxl-icon-preview icon-${name} ${isDeprecated ? 'deprecated' : ''}"
-          title="${title}"
-        >
-          <iron-icon icon="${iconsetName}:${name}"></iron-icon>
-          <span class="cxl-icon-preview-name">${name}</div>
-        </div>`;
+      iconTemplate = html` <div
+        class="cxl-icon-preview icon-${name} ${isDeprecated ? 'deprecated' : ''}"
+        title="${title}"
+      >
+        <vaadin-icon icon="${iconsetName}:${name}"></vaadin-icon>
+        <span class="cxl-icon-preview-name">${name}</span>
+      </div>`;
 
       iconsTemplate.push(iconTemplate);
     });

--- a/packages/storybook/cxl-ui/cxl-app-layout/layout=1c-c.stories.js
+++ b/packages/storybook/cxl-ui/cxl-app-layout/layout=1c-c.stories.js
@@ -32,10 +32,10 @@ export const CXLAppLayout1cc = () => html`
         </ul>
         <p>
           <vaadin-button theme="primary large"
-            >Marketing training <iron-icon icon="lumo:angle-right" slot="suffix"></iron-icon
+            >Marketing training <vaadin-icon icon="lumo:angle-right" slot="suffix"></vaadin-icon
           ></vaadin-button>
           <vaadin-button theme="primary large contrast"
-            >Managed services <iron-icon icon="lumo:angle-right" slot="suffix"></iron-icon
+            >Managed services <vaadin-icon icon="lumo:angle-right" slot="suffix"></vaadin-icon
           ></vaadin-button>
         </p>
       </div>

--- a/packages/storybook/cxl-ui/cxl-app-layout/layout=1c.stories.js
+++ b/packages/storybook/cxl-ui/cxl-app-layout/layout=1c.stories.js
@@ -46,10 +46,10 @@ export const CXLAppLayout = () => {
             </ul>
             <p>
               <vaadin-button theme="primary large"
-                >Marketing training <iron-icon icon="lumo:angle-right" slot="suffix"></iron-icon
+                >Marketing training <vaadin-icon icon="lumo:angle-right" slot="suffix"></vaadin-icon
               ></vaadin-button>
               <vaadin-button theme="primary large contrast"
-                >Managed services <iron-icon icon="lumo:angle-right" slot="suffix"></iron-icon
+                >Managed services <vaadin-icon icon="lumo:angle-right" slot="suffix"></vaadin-icon
               ></vaadin-button>
             </p>
           </cxl-section>

--- a/packages/storybook/cxl-ui/cxl-app-layout/layout=2c-l.stories.js
+++ b/packages/storybook/cxl-ui/cxl-app-layout/layout=2c-l.stories.js
@@ -53,11 +53,11 @@ const Template = ({ hasWidgetBackground, postId, userId, playbookSaved }) => htm
 
       <p>
         <vaadin-button theme="tertiary contrast"
-          >Share <iron-icon icon="lumo:cog" slot="prefix"></iron-icon
+          >Share <vaadin-icon icon="lumo:cog" slot="prefix"></vaadin-icon
         ></vaadin-button>
         <br />
         <vaadin-button theme="tertiary contrast"
-          >Report <iron-icon icon="lumo:error" slot="prefix"></iron-icon
+          >Report <vaadin-icon icon="lumo:error" slot="prefix"></vaadin-icon
         ></vaadin-button>
       </p>
       <p>

--- a/packages/storybook/cxl-ui/cxl-app-layout/layout=2c-r.stories.js
+++ b/packages/storybook/cxl-ui/cxl-app-layout/layout=2c-r.stories.js
@@ -51,7 +51,7 @@ export const CXLAppLayout2cr = () => {
         >
           <header class="entry-header">
             <h4 class="entry-title no-anchor" itemprop="headline">
-              <iron-icon class="iron-icon" icon="vaadin:play-circle-o"></iron-icon>
+              <vaadin-icon class="vaadin-icon" icon="vaadin:play-circle-o"></vaadin-icon>
               <a
                 href="https://conversionxli.warmpress.com/lesson/persuasion-slide-introduction/"
                 rel="bookmark"
@@ -72,7 +72,7 @@ export const CXLAppLayout2cr = () => {
         >
           <header class="entry-header">
             <h4 class="entry-title no-anchor" itemprop="headline">
-              <iron-icon class="iron-icon" icon="lumo:angle-right"></iron-icon>
+              <vaadin-icon class="vaadin-icon" icon="lumo:angle-right"></vaadin-icon>
               <a
                 href="https://conversionxli.warmpress.com/lesson/2-persuasion-psychology-brief-introduction/"
                 rel="bookmark"
@@ -94,7 +94,7 @@ export const CXLAppLayout2cr = () => {
         >
           <header class="entry-header">
             <h4 class="entry-title no-anchor" itemprop="headline">
-              <iron-icon class="iron-icon" icon="vaadin:play-circle-o"></iron-icon>
+              <vaadin-icon class="vaadin-icon" icon="vaadin:play-circle-o"></vaadin-icon>
               <a
                 href="https://conversionxli.warmpress.com/lesson/3-persuasion-slide/"
                 rel="bookmark"
@@ -115,7 +115,7 @@ export const CXLAppLayout2cr = () => {
         >
           <header class="entry-header">
             <h4 class="entry-title no-anchor" itemprop="headline">
-              <iron-icon class="iron-icon" icon="lumo:angle-right"></iron-icon>
+              <vaadin-icon class="vaadin-icon" icon="lumo:angle-right"></vaadin-icon>
               <a
                 href="https://conversionxli.warmpress.com/lesson/4-gravity/"
                 rel="bookmark"
@@ -136,7 +136,7 @@ export const CXLAppLayout2cr = () => {
         >
           <header class="entry-header">
             <h4 class="entry-title no-anchor" itemprop="headline">
-              <iron-icon class="iron-icon" icon="vaadin:play-circle-o"></iron-icon>
+              <vaadin-icon class="vaadin-icon" icon="vaadin:play-circle-o"></vaadin-icon>
               <a
                 href="https://conversionxli.warmpress.com/lesson/5-nudge/"
                 rel="bookmark"
@@ -157,7 +157,7 @@ export const CXLAppLayout2cr = () => {
         >
           <header class="entry-header">
             <h4 class="entry-title no-anchor" itemprop="headline">
-              <iron-icon class="iron-icon" icon="vaadin:check-circle"></iron-icon>
+              <vaadin-icon class="vaadin-icon" icon="vaadin:check-circle"></vaadin-icon>
               <a
                 href="https://conversionxli.warmpress.com/lesson/6-angle-conscious-motivation/"
                 rel="bookmark"
@@ -178,7 +178,7 @@ export const CXLAppLayout2cr = () => {
         >
           <header class="entry-header">
             <h4 class="entry-title no-anchor" itemprop="headline">
-              <iron-icon class="iron-icon" icon="vaadin:check-circle"></iron-icon>
+              <vaadin-icon class="vaadin-icon" icon="vaadin:check-circle"></vaadin-icon>
               <a
                 href="https://conversionxli.warmpress.com/lesson/7-angle-unconscious-motivation/"
                 rel="bookmark"
@@ -199,7 +199,7 @@ export const CXLAppLayout2cr = () => {
         >
           <header class="entry-header">
             <h4 class="entry-title no-anchor" itemprop="headline">
-              <iron-icon class="iron-icon" icon="vaadin:check-circle"></iron-icon>
+              <vaadin-icon class="vaadin-icon" icon="vaadin:check-circle"></vaadin-icon>
               <a
                 href="https://conversionxli.warmpress.com/lesson/8-friction-real-difficulty/"
                 rel="bookmark"
@@ -220,7 +220,7 @@ export const CXLAppLayout2cr = () => {
         >
           <header class="entry-header">
             <h4 class="entry-title no-anchor" itemprop="headline">
-              <iron-icon class="iron-icon" icon="vaadin:check-circle"></iron-icon>
+              <vaadin-icon class="vaadin-icon" icon="vaadin:check-circle"></vaadin-icon>
               <a
                 href="https://conversionxli.warmpress.com/lesson/9-friction-imaginary-friction-cognitive-fluency/"
                 rel="bookmark"
@@ -242,7 +242,7 @@ export const CXLAppLayout2cr = () => {
         >
           <header class="entry-header">
             <h4 class="entry-title no-anchor" itemprop="headline">
-              <iron-icon class="iron-icon" icon="lumo:angle-right"></iron-icon>
+              <vaadin-icon class="vaadin-icon" icon="lumo:angle-right"></vaadin-icon>
               <a
                 href="https://conversionxli.warmpress.com/lesson/10-build-slide/"
                 rel="bookmark"
@@ -356,17 +356,17 @@ export const CXLAppLayout2cr = () => {
 
       <div slot="action-bar">
         <vaadin-button theme="primary"
-          >Complete lesson <iron-icon icon="vaadin:check-circle" slot="suffix"></iron-icon
+          >Complete lesson <vaadin-icon icon="vaadin:check-circle" slot="suffix"></vaadin-icon
         ></vaadin-button>
         <vaadin-button>Secondary action</vaadin-button>
         <vaadin-context-menu selector="vaadin-button" open-on="click" theme="cxl-marketing-nav">
           <template>
             <vaadin-context-menu-list-box theme="cxl-marketing-nav">
               <vaadin-context-menu-item class="vaadin-menu-item" theme="cxl-marketing-nav"
-                >Next lesson <iron-icon icon="lumo:arrow-right"></iron-icon
+                >Next lesson <vaadin-icon icon="lumo:arrow-right"></vaadin-icon
               ></vaadin-context-menu-item>
               <vaadin-context-menu-item class="vaadin-menu-item" theme="cxl-marketing-nav"
-                ><iron-icon icon="lumo:arrow-left"></iron-icon> Previous
+                ><vaadin-icon icon="lumo:arrow-left"></vaadin-icon> Previous
                 lesson</vaadin-context-menu-item
               >
               <hr />
@@ -376,7 +376,7 @@ export const CXLAppLayout2cr = () => {
             </vaadin-context-menu-list-box>
           </template>
           <vaadin-button theme="icon contrast" aria-label="More actions"
-            ><iron-icon icon="vaadin:ellipsis-dots-v"></iron-icon
+            ><vaadin-icon icon="vaadin:ellipsis-dots-v"></vaadin-icon
           ></vaadin-button>
         </vaadin-context-menu>
       </div>

--- a/packages/storybook/cxl-ui/cxl-marketing-nav.data.json
+++ b/packages/storybook/cxl-ui/cxl-marketing-nav.data.json
@@ -30,7 +30,7 @@
   "primary": [
     {
       "depth": 0,
-      "text": "My dashboard <iron-icon icon=\"lumo:dropdown\"><\/iron-icon>",
+      "text": "My dashboard <vaadin-icon icon=\"lumo:dropdown\"><\/vaadin-icon>",
       "component": "a",
       "href": "https:\/\/conversionxl.com\/institute\/dashboard\/",
       "id": 35,
@@ -72,7 +72,7 @@
     },
     {
       "depth": 0,
-      "text": "Minidegrees <iron-icon icon=\"lumo:dropdown\"><\/iron-icon>",
+      "text": "Minidegrees <vaadin-icon icon=\"lumo:dropdown\"><\/vaadin-icon>",
       "component": "a",
       "href": "https:\/\/conversionxl.com\/institute\/online-courses\/?_categories=minidegree-programs",
       "id": 36,
@@ -114,7 +114,7 @@
     },
     {
       "depth": 0,
-      "text": "Online courses <iron-icon icon=\"lumo:dropdown\"><\/iron-icon>",
+      "text": "Online courses <vaadin-icon icon=\"lumo:dropdown\"><\/vaadin-icon>",
       "component": "a",
       "href": "https:\/\/conversionxl.com\/institute\/online-courses\/",
       "id": 37,
@@ -420,7 +420,7 @@
     },
     {
       "depth": 0,
-      "text": "<iron-icon icon=\"lumo:plus\"><\/iron-icon> Invite team",
+      "text": "<vaadin-icon icon=\"lumo:plus\"><\/vaadin-icon> Invite team",
       "component": "a",
       "href": "https:\/\/conversionxl.com\/institute\/my-account\/teams\/",
       "id": 40,
@@ -428,7 +428,7 @@
     },
     {
       "depth": 0,
-      "text": "<iron-icon icon=\"lumo:user\"><\/iron-icon> My account <iron-icon icon=\"lumo:dropdown\"><\/iron-icon>",
+      "text": "<vaadin-icon icon=\"lumo:user\"><\/vaadin-icon> My account <vaadin-icon icon=\"lumo:dropdown\"><\/vaadin-icon>",
       "component": "a",
       "href": "https:\/\/conversionxl.com\/institute\/my-account\/",
       "id": 41,

--- a/packages/storybook/cxl-ui/cxl-marketing-nav.stories.js
+++ b/packages/storybook/cxl-ui/cxl-marketing-nav.stories.js
@@ -39,7 +39,7 @@ export const CXLMarketingNav = () => {
               theme="icon"
               onclick="document.getElementById('search-form').submit();"
             >
-              <iron-icon icon="lumo:angle-right"></iron-icon>
+              <vaadin-icon icon="lumo:angle-right"></vaadin-icon>
             </vaadin-button>
           </form>
         </vaadin-context-menu-item>
@@ -54,7 +54,10 @@ export const CXLMarketingNav = () => {
       >
         <vaadin-tab class="menu-item menu-item-logo menu-item-wide" theme="cxl-marketing-nav">
           <a href="https://conversionxl.com"
-            ><iron-icon icon="cxl:logo" style="width: var(--lumo-icon-size-xl, 48px);"></iron-icon
+            ><vaadin-icon
+              icon="cxl:logo"
+              style="width: var(--lumo-icon-size-xl, 48px);"
+            ></vaadin-icon
           ></a>
         </vaadin-tab>
         <vaadin-tab
@@ -69,7 +72,7 @@ export const CXLMarketingNav = () => {
           theme="cxl-marketing-nav"
         >
           <a href="https://conversionxl.com/agency/"
-            >Conversion optimization services <iron-icon icon="lumo:dropdown"></iron-icon
+            >Conversion optimization services <vaadin-icon icon="lumo:dropdown"></vaadin-icon
           ></a>
           <vaadin-context-menu
             open-on="click"
@@ -88,15 +91,15 @@ export const CXLMarketingNav = () => {
         <vaadin-tab class="menu-item" theme="cxl-marketing-nav"
           ><a href="https://conversionxl.com/live/"
             >CXL Live 2020
-            <iron-icon icon="cxl:live" style="color: var(--lumo-primary-color)"></iron-icon></a
+            <vaadin-icon icon="cxl:live" style="color: var(--lumo-primary-color)"></vaadin-icon></a
         ></vaadin-tab>
         <vaadin-tab
           class="menu-item menu-item-split-nav menu-item-has-children menu-item-wide menu-item-search"
           theme="cxl-marketing-nav"
         >
           <a
-            ><iron-icon icon="lumo:search"></iron-icon> Search
-            <iron-icon icon="lumo:dropdown"></iron-icon
+            ><vaadin-icon icon="lumo:search"></vaadin-icon> Search
+            <vaadin-icon icon="lumo:dropdown"></vaadin-icon
           ></a>
         </vaadin-tab>
       </vaadin-tabs>
@@ -114,7 +117,7 @@ export const CXLMarketingNav = () => {
           theme="cxl-marketing-nav"
         >
           <a href="https://conversionxl.com/institute/dashboard/"
-            >My dashboard <iron-icon icon="lumo:dropdown"></iron-icon
+            >My dashboard <vaadin-icon icon="lumo:dropdown"></vaadin-icon
           ></a>
           <vaadin-context-menu
             open-on="click"
@@ -129,7 +132,7 @@ export const CXLMarketingNav = () => {
         >
           <a
             href="https://conversionxl.com/institute/online-courses/?_categories=minidegree-programs"
-            >Minidegrees <iron-icon icon="lumo:dropdown"></iron-icon
+            >Minidegrees <vaadin-icon icon="lumo:dropdown"></vaadin-icon
           ></a>
           <vaadin-context-menu
             open-on="click"
@@ -143,7 +146,7 @@ export const CXLMarketingNav = () => {
           theme="cxl-marketing-nav"
         >
           <a href="https://conversionxl.com/institute/online-courses/"
-            >Online courses <iron-icon icon="lumo:dropdown"></iron-icon
+            >Online courses <vaadin-icon icon="lumo:dropdown"></vaadin-icon
           ></a>
           <vaadin-context-menu
             open-on="click"
@@ -161,7 +164,7 @@ export const CXLMarketingNav = () => {
         >
         <vaadin-tab class="menu-item menu-item-split-nav" theme="cxl-marketing-nav"
           ><a href="https://conversionxl.com/institute/my-account/teams/"
-            ><iron-icon icon="lumo:plus"></iron-icon> Invite team</a
+            ><vaadin-icon icon="lumo:plus"></vaadin-icon> Invite team</a
           ></vaadin-tab
         >
         <vaadin-tab
@@ -169,8 +172,8 @@ export const CXLMarketingNav = () => {
           class="menu-item menu-item-has-children"
           theme="cxl-marketing-nav"
           ><a href="https://conversionxl.com/institute/my-account/"
-            ><iron-icon icon="lumo:user"></iron-icon> My account
-            <iron-icon icon="lumo:dropdown"></iron-icon
+            ><vaadin-icon icon="lumo:user"></vaadin-icon> My account
+            <vaadin-icon icon="lumo:dropdown"></vaadin-icon
           ></a>
           <vaadin-context-menu
             open-on="click"

--- a/packages/storybook/cxl-ui/cxl-notification/gravity-form.story.js
+++ b/packages/storybook/cxl-ui/cxl-notification/gravity-form.story.js
@@ -23,7 +23,7 @@ export const GravityFormStory = ({}) => html`
           theme="primary icon"
           onclick="document.getElementById('gform_83_vaadin_notification_1').close()"
         >
-          <iron-icon icon="lumo:cross"></iron-icon>
+          <vaadin-icon icon="lumo:cross"></vaadin-icon>
         </vaadin-button>
       </vaadin-horizontal-layout>
     </cxl-notification>
@@ -56,7 +56,7 @@ export const GravityFormStory = ({}) => html`
           theme="primary icon"
           onclick="document.getElementById('gform_20_vaadin_notification_1').close()"
         >
-          <iron-icon icon="lumo:cross"></iron-icon>
+          <vaadin-icon icon="lumo:cross"></vaadin-icon>
         </vaadin-button>
       </vaadin-horizontal-layout>
     </cxl-notification>

--- a/packages/storybook/cxl-ui/cxl-notification/unpaid-order.story.js
+++ b/packages/storybook/cxl-ui/cxl-notification/unpaid-order.story.js
@@ -23,7 +23,7 @@ export const UnPaidOrderStory = ({}) => html`
           theme="primary icon"
           onclick="document.getElementById('6351798_vaadin_notification_1').close()"
         >
-          <iron-icon icon="lumo:cross"></iron-icon>
+          <vaadin-icon icon="lumo:cross"></vaadin-icon>
         </vaadin-button>
       </vaadin-horizontal-layout>
     </cxl-notification>

--- a/packages/storybook/cxl-ui/cxl-paywall/cxl-paywall-layout=2c-l.stories.js
+++ b/packages/storybook/cxl-ui/cxl-paywall/cxl-paywall-layout=2c-l.stories.js
@@ -46,11 +46,11 @@ const Template = ({ _count, _limit, delay, opacity, subscribed }) => html`
       <p>Rate this playbook ${CXLStarRating()}</p>
       <p>
         <vaadin-button theme="tertiary contrast"
-          >Share <iron-icon icon="lumo:cog" slot="prefix"></iron-icon
+          >Share <vaadin-icon icon="lumo:cog" slot="prefix"></vaadin-icon
         ></vaadin-button>
         <br />
         <vaadin-button theme="tertiary contrast"
-          >Report <iron-icon icon="lumo:error" slot="prefix"></iron-icon
+          >Report <vaadin-icon icon="lumo:error" slot="prefix"></vaadin-icon
         ></vaadin-button>
       </p>
     </section>

--- a/packages/storybook/cxl-ui/cxl-vaadin-accordion/cxl-accordion-card.story.js
+++ b/packages/storybook/cxl-ui/cxl-vaadin-accordion/cxl-accordion-card.story.js
@@ -85,7 +85,7 @@ export const CXLVaadinAccordionThemeArchive = () => {
                 />
               </a>
               <div class="entry-byline">
-                <iron-icon icon="lumo:clock"></iron-icon>${el.conversionxl_live_course_duration}
+                <vaadin-icon icon="lumo:clock"></vaadin-icon>${el.conversionxl_live_course_duration}
                 <hr />
                 Instructors: ${el.conversionxl_certificate_instructor}
               </div>
@@ -95,7 +95,7 @@ export const CXLVaadinAccordionThemeArchive = () => {
             </div>
             <div class="entry-footer" style="text-align: right;">
               <a href="${el.conversionxl_certificate_sales_page}"
-                >View training<iron-icon icon="lumo:angle-right"></iron-icon
+                >View training<vaadin-icon icon="lumo:angle-right"></vaadin-icon
               ></a>
             </div>
           </cxl-accordion-card>

--- a/packages/storybook/cxl-ui/cxl-vaadin-accordion/cxl-playbook-accordion.story.js
+++ b/packages/storybook/cxl-ui/cxl-vaadin-accordion/cxl-playbook-accordion.story.js
@@ -18,7 +18,7 @@ export const CXLPlaybookAccordion = ({ FeedbackButtonLabel, PlaybookId }) => htm
             <vaadin-button
               onclick="alert('Step ID: ' + this.closest('vaadin-accordion-panel').dataset.stepId)"
             >
-              <iron-icon icon="vaadin:comment" slot="prefix"></iron-icon>
+              <vaadin-icon icon="vaadin:comment" slot="prefix"></vaadin-icon>
               ${FeedbackButtonLabel}
             </vaadin-button>
           </div>

--- a/packages/storybook/cxl-ui/cxl-vaadin-accordion/partials/cxl-hub-card-display.js
+++ b/packages/storybook/cxl-ui/cxl-vaadin-accordion/partials/cxl-hub-card-display.js
@@ -56,7 +56,7 @@ const CxlHubCardDisplay = (el, userId, selected) => html`
       <div class="ttr_end"></div>
       <div class="entry-footer" style="text-align: right;">
         <a href="https://cxl.com/institute/online-course/ab-testing-mastery/" title="Open"
-          >Open<iron-icon icon="lumo:angle-right"></iron-icon
+          >Open<vaadin-icon icon="lumo:angle-right"></vaadin-icon
         ></a>
       </div>
     </div>

--- a/packages/storybook/cxl-ui/cxl-vaadin-accordion/partials/cxl-singleversion-card-display.js
+++ b/packages/storybook/cxl-ui/cxl-vaadin-accordion/partials/cxl-singleversion-card-display.js
@@ -51,7 +51,7 @@ const CxlSingleversionCardDisplay = (el, userId, selected) => {
         </ol>
         <div class="entry-footer" style="text-align: right;">
           <a href="https://cxl.com/institute/online-course/ab-testing-mastery/" title="Open"
-            >Open<iron-icon icon="lumo:angle-right"></iron-icon
+            >Open<vaadin-icon icon="lumo:angle-right"></vaadin-icon
           ></a>
         </div>
       </div>

--- a/packages/storybook/cxl-ui/cxl-vaadin-accordion/theme=cxl-minidegree-track.story.js
+++ b/packages/storybook/cxl-ui/cxl-vaadin-accordion/theme=cxl-minidegree-track.story.js
@@ -61,7 +61,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   height="150"
               /></a>
               <h4 class="entry-title no-anchor" itemprop="headline">
-                <iron-icon icon="vaadin:check-circle"></iron-icon>
+                <vaadin-icon icon="vaadin:check-circle"></vaadin-icon>
                 <a
                   href="https://conversionxli.warmpress.com/course/cro-foundations/"
                   rel="bookmark"
@@ -92,7 +92,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   href="https://conversionxli.warmpress.com/course/cro-foundations/#more-17689"
                   class="more-link"
                   ><span aria-label="Continue reading CRO foundations"
-                    >See course <iron-icon icon="lumo:angle-right"></iron-icon></span
+                    >See course <vaadin-icon icon="lumo:angle-right"></vaadin-icon></span
                 ></a>
               </p>
             </div>
@@ -116,7 +116,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                 height="150"
               />
               <h4 class="entry-title no-anchor" itemprop="headline">
-                <iron-icon icon="vaadin:check-circle"></iron-icon>
+                <vaadin-icon icon="vaadin:check-circle"></vaadin-icon>
                 <a
                   href="https://conversionxli.warmpress.com/course/best-practices/"
                   rel="bookmark"
@@ -161,7 +161,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   href="https://conversionxli.warmpress.com/course/best-practices/#more-19335"
                   class="more-link"
                   ><span aria-label="Continue reading Best Practices"
-                    >See course <iron-icon icon="lumo:angle-right"></iron-icon></span
+                    >See course <vaadin-icon icon="lumo:angle-right"></vaadin-icon></span
                 ></a>
               </p>
             </div>
@@ -186,7 +186,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   height="150"
               /></a>
               <h4 class="entry-title no-anchor" itemprop="headline">
-                <iron-icon icon="vaadin:play-circle-o"></iron-icon>
+                <vaadin-icon icon="vaadin:play-circle-o"></vaadin-icon>
                 <a
                   href="https://conversionxli.warmpress.com/course/conversion-copywriting/"
                   rel="bookmark"
@@ -214,7 +214,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   href="https://conversionxli.warmpress.com/course/conversion-copywriting/#more-17706"
                   class="more-link"
                   ><span aria-label="Continue reading Conversion Copywriting"
-                    >See course <iron-icon icon="lumo:angle-right"></iron-icon></span
+                    >See course <vaadin-icon icon="lumo:angle-right"></vaadin-icon></span
                 ></a>
               </p>
             </div>
@@ -240,7 +240,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   height="150"
               /></a>
               <h4 class="entry-title no-anchor" itemprop="headline">
-                <iron-icon icon="vaadin:play-circle-o"></iron-icon>
+                <vaadin-icon icon="vaadin:play-circle-o"></vaadin-icon>
                 <a
                   href="https://conversionxli.warmpress.com/course/product-messaging-sales-page-copywriting/"
                   rel="bookmark"
@@ -263,7 +263,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   href="https://conversionxli.warmpress.com/course/product-messaging-sales-page-copywriting/#more-28479"
                   class="more-link"
                   ><span aria-label="Continue reading Product messaging &amp; salespage copywriting"
-                    >See course <iron-icon icon="lumo:angle-right"></iron-icon></span
+                    >See course <vaadin-icon icon="lumo:angle-right"></vaadin-icon></span
                 ></a>
               </p>
             </div>
@@ -288,7 +288,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   height="150"
               /></a>
               <h4 class="entry-title no-anchor" itemprop="headline">
-                <iron-icon icon="lumo:angle-right"></iron-icon>
+                <vaadin-icon icon="lumo:angle-right"></vaadin-icon>
                 <a
                   href="https://conversionxli.warmpress.com/course/people-and-psychology/"
                   rel="bookmark"
@@ -318,7 +318,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   href="https://conversionxli.warmpress.com/course/people-and-psychology/#more-17701"
                   class="more-link"
                   ><span aria-label="Continue reading Intro to Web Psychology"
-                    >See course <iron-icon icon="lumo:angle-right"></iron-icon></span
+                    >See course <vaadin-icon icon="lumo:angle-right"></vaadin-icon></span
                 ></a>
               </p>
             </div>
@@ -343,7 +343,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   height="150"
               /></a>
               <h4 class="entry-title no-anchor" itemprop="headline">
-                <iron-icon icon="lumo:angle-right"></iron-icon>
+                <vaadin-icon icon="lumo:angle-right"></vaadin-icon>
                 <a
                   href="https://conversionxli.warmpress.com/course/social-proof/"
                   rel="bookmark"
@@ -384,7 +384,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   href="https://conversionxli.warmpress.com/course/social-proof/#more-4311"
                   class="more-link"
                   ><span aria-label="Continue reading Social Proof"
-                    >See course <iron-icon icon="lumo:angle-right"></iron-icon></span
+                    >See course <vaadin-icon icon="lumo:angle-right"></vaadin-icon></span
                 ></a>
               </p>
             </div>
@@ -409,7 +409,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   height="150"
               /></a>
               <h4 class="entry-title no-anchor" itemprop="headline">
-                <iron-icon icon="lumo:angle-right"></iron-icon>
+                <vaadin-icon icon="lumo:angle-right"></vaadin-icon>
                 <a
                   href="https://conversionxli.warmpress.com/course/intro-to-neuromarketing/"
                   rel="bookmark"
@@ -436,7 +436,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   href="https://conversionxli.warmpress.com/course/intro-to-neuromarketing/#more-226965"
                   class="more-link"
                   ><span aria-label="Continue reading Intro to Neuromarketing"
-                    >See course <iron-icon icon="lumo:angle-right"></iron-icon></span
+                    >See course <vaadin-icon icon="lumo:angle-right"></vaadin-icon></span
                 ></a>
               </p>
             </div>
@@ -462,7 +462,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   height="150"
               /></a>
               <h4 class="entry-title no-anchor" itemprop="headline">
-                <iron-icon icon="lumo:angle-right"></iron-icon>
+                <vaadin-icon icon="lumo:angle-right"></vaadin-icon>
                 <a
                   href="https://conversionxli.warmpress.com/course/developing-testing-an-emotional-content-strategy/"
                   rel="bookmark"
@@ -493,7 +493,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   class="more-link"
                   ><span
                     aria-label="Continue reading Developing &amp; Testing an Emotional Content Strategy"
-                    >See course <iron-icon icon="lumo:angle-right"></iron-icon></span
+                    >See course <vaadin-icon icon="lumo:angle-right"></vaadin-icon></span
                 ></a>
               </p>
             </div>
@@ -518,7 +518,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   height="150"
               /></a>
               <h4 class="entry-title no-anchor" itemprop="headline">
-                <iron-icon icon="lumo:angle-right"></iron-icon>
+                <vaadin-icon icon="lumo:angle-right"></vaadin-icon>
                 <a
                   href="https://conversionxli.warmpress.com/course/influence-interactive-design/"
                   rel="bookmark"
@@ -560,7 +560,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   href="https://conversionxli.warmpress.com/course/influence-interactive-design/#more-6764"
                   class="more-link"
                   ><span aria-label="Continue reading Influence and interactive design"
-                    >See course <iron-icon icon="lumo:angle-right"></iron-icon></span
+                    >See course <vaadin-icon icon="lumo:angle-right"></vaadin-icon></span
                 ></a>
               </p>
             </div>
@@ -585,7 +585,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   height="150"
               /></a>
               <h4 class="entry-title no-anchor" itemprop="headline">
-                <iron-icon icon="lumo:angle-right"></iron-icon>
+                <vaadin-icon icon="lumo:angle-right"></vaadin-icon>
                 <a
                   href="https://conversionxli.warmpress.com/course/intro-digital-analytics/"
                   rel="bookmark"
@@ -615,7 +615,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   href="https://conversionxli.warmpress.com/course/intro-digital-analytics/#more-3708"
                   class="more-link"
                   ><span aria-label="Continue reading Intro to Digital Analytics"
-                    >See course <iron-icon icon="lumo:angle-right"></iron-icon></span
+                    >See course <vaadin-icon icon="lumo:angle-right"></vaadin-icon></span
                 ></a>
               </p>
             </div>
@@ -640,7 +640,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   height="150"
               /></a>
               <h4 class="entry-title no-anchor" itemprop="headline">
-                <iron-icon icon="lumo:angle-right"></iron-icon>
+                <vaadin-icon icon="lumo:angle-right"></vaadin-icon>
                 <a
                   href="https://conversionxli.warmpress.com/course/google-analytics-beginners/"
                   rel="bookmark"
@@ -664,7 +664,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   href="https://conversionxli.warmpress.com/course/google-analytics-beginners/#more-179345"
                   class="more-link"
                   ><span aria-label="Continue reading Google Analytics for beginners"
-                    >See course <iron-icon icon="lumo:angle-right"></iron-icon></span
+                    >See course <vaadin-icon icon="lumo:angle-right"></vaadin-icon></span
                 ></a>
               </p>
             </div>
@@ -719,7 +719,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   height="150"
               /></a>
               <h4 class="entry-title no-anchor" itemprop="headline">
-                <iron-icon icon="lumo:angle-right"></iron-icon>
+                <vaadin-icon icon="lumo:angle-right"></vaadin-icon>
                 <a
                   href="https://conversionxli.warmpress.com/course/conversion-research/"
                   rel="bookmark"
@@ -748,7 +748,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   href="https://conversionxli.warmpress.com/course/conversion-research/#more-17707"
                   class="more-link"
                   ><span aria-label="Continue reading Conversion Research"
-                    >See course <iron-icon icon="lumo:angle-right"></iron-icon></span
+                    >See course <vaadin-icon icon="lumo:angle-right"></vaadin-icon></span
                 ></a>
               </p>
             </div>
@@ -774,7 +774,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   height="150"
               /></a>
               <h4 class="entry-title no-anchor" itemprop="headline">
-                <iron-icon icon="lumo:angle-right"></iron-icon>
+                <vaadin-icon icon="lumo:angle-right"></vaadin-icon>
                 <a
                   href="https://conversionxli.warmpress.com/course/using-analytics-to-find-conversion-opportunities/"
                   rel="bookmark"
@@ -812,7 +812,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   class="more-link"
                   ><span
                     aria-label="Continue reading Using analytics to find conversion opportunities"
-                    >See course <iron-icon icon="lumo:angle-right"></iron-icon></span
+                    >See course <vaadin-icon icon="lumo:angle-right"></vaadin-icon></span
                 ></a>
               </p>
             </div>
@@ -837,7 +837,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   height="150"
               /></a>
               <h4 class="entry-title no-anchor" itemprop="headline">
-                <iron-icon icon="lumo:angle-right"></iron-icon>
+                <vaadin-icon icon="lumo:angle-right"></vaadin-icon>
                 <a
                   href="https://conversionxli.warmpress.com/course/google-tag-manager-for-beginners/"
                   rel="bookmark"
@@ -879,7 +879,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   href="https://conversionxli.warmpress.com/course/google-tag-manager-for-beginners/#more-112809"
                   class="more-link"
                   ><span aria-label="Continue reading Google Tag Manager for beginners"
-                    >See course <iron-icon icon="lumo:angle-right"></iron-icon></span
+                    >See course <vaadin-icon icon="lumo:angle-right"></vaadin-icon></span
                 ></a>
               </p>
             </div>
@@ -904,7 +904,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   height="150"
               /></a>
               <h4 class="entry-title no-anchor" itemprop="headline">
-                <iron-icon icon="lumo:angle-right"></iron-icon>
+                <vaadin-icon icon="lumo:angle-right"></vaadin-icon>
                 <a
                   href="https://conversionxli.warmpress.com/course/fast-and-rigorous-user-personas/"
                   rel="bookmark"
@@ -941,7 +941,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   href="https://conversionxli.warmpress.com/course/fast-and-rigorous-user-personas/#more-16305"
                   class="more-link"
                   ><span aria-label="Continue reading Fast and Rigorous User Personas"
-                    >See course <iron-icon icon="lumo:angle-right"></iron-icon></span
+                    >See course <vaadin-icon icon="lumo:angle-right"></vaadin-icon></span
                 ></a>
               </p>
             </div>
@@ -966,7 +966,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   height="150"
               /></a>
               <h4 class="entry-title no-anchor" itemprop="headline">
-                <iron-icon icon="lumo:angle-right"></iron-icon>
+                <vaadin-icon icon="lumo:angle-right"></vaadin-icon>
                 <a
                   href="https://conversionxli.warmpress.com/course/conversion-optimization-audits/"
                   rel="bookmark"
@@ -990,7 +990,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   class="more-link"
                   ><span
                     aria-label="Continue reading Heuristic analysis frameworks for conversion optimization audits"
-                    >See course <iron-icon icon="lumo:angle-right"></iron-icon></span
+                    >See course <vaadin-icon icon="lumo:angle-right"></vaadin-icon></span
                 ></a>
               </p>
             </div>
@@ -1015,7 +1015,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   height="150"
               /></a>
               <h4 class="entry-title no-anchor" itemprop="headline">
-                <iron-icon icon="lumo:angle-right"></iron-icon>
+                <vaadin-icon icon="lumo:angle-right"></vaadin-icon>
                 <a
                   href="https://conversionxli.warmpress.com/course/conducting-an-analytics-audit/"
                   rel="bookmark"
@@ -1047,7 +1047,7 @@ export const CXLVaadinAccordionThemeMinidegreeTrack = () => html`
                   href="https://conversionxli.warmpress.com/course/conducting-an-analytics-audit/#more-12230"
                   class="more-link"
                   ><span aria-label="Continue reading Conducting an analytics audit"
-                    >See course <iron-icon icon="lumo:angle-right"></iron-icon></span
+                    >See course <vaadin-icon icon="lumo:angle-right"></vaadin-icon></span
                 ></a>
               </p>
             </div>

--- a/packages/storybook/cxl-ui/footer-nav.stories.js
+++ b/packages/storybook/cxl-ui/footer-nav.stories.js
@@ -34,7 +34,10 @@ export const CXLFooterNav = () => html`
         <ul class="menu-items">
           <li class="menu-item" style="color: var(--lumo-tint)">
             <a href="https://cxl.com"
-              ><iron-icon icon="cxl:logo" style="width: var(--lumo-icon-size-xl, 48px);"></iron-icon
+              ><vaadin-icon
+                icon="cxl:logo"
+                style="width: var(--lumo-icon-size-xl, 48px);"
+              ></vaadin-icon
             ></a>
             ©2011-2021
           </li>

--- a/packages/storybook/gravity-forms/index.stories.js
+++ b/packages/storybook/gravity-forms/index.stories.js
@@ -161,7 +161,7 @@ const formTemplate = html`
           theme="primary"
           tabindex="0"
           role="button"
-          >Get launch updates<iron-icon icon="lumo:angle-right" slot="suffix"></iron-icon
+          >Get launch updates<vaadin-icon icon="lumo:angle-right" slot="suffix"></vaadin-icon
         ></vaadin-button>
         <input
           type="hidden"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1269,14 +1269,6 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@cwmr/iron-star-rating@github:conversionxl/iron-star-rating":
-  version "3.1.4"
-  resolved "https://codeload.github.com/conversionxl/iron-star-rating/tar.gz/6e5258fb2b8ec8b30cc9b723b8a26d7bcbc2540b"
-  dependencies:
-    "@polymer/iron-icon" "^3.0.0"
-    "@polymer/iron-icons" "^3.0.0"
-    "@polymer/polymer" "^3.0.0"
-
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
@@ -2587,7 +2579,7 @@
   dependencies:
     "@polymer/polymer" "^3.0.0"
 
-"@polymer/iron-icon@^3.0.0", "@polymer/iron-icon@^3.0.0-pre.26":
+"@polymer/iron-icon@^3.0.0":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@polymer/iron-icon/-/iron-icon-3.0.1.tgz#93211c39d8825fe4965a68419566036c1df291eb"
   integrity sha512-QLPwirk+UPZNaLnMew9VludXA4CWUCenRewgEcGYwdzVgDPCDbXxy6vRJjmweZobMQv/oVLppT2JZtJFnPxX6g==
@@ -2596,16 +2588,7 @@
     "@polymer/iron-meta" "^3.0.0-pre.26"
     "@polymer/polymer" "^3.0.0"
 
-"@polymer/iron-icons@^3.0.0":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/iron-icons/-/iron-icons-3.0.1.tgz#c1bd31d8483afbdb5422cdc384081e19c9267cfe"
-  integrity sha512-xtEI8erH2GIBiF3QxEMyW81XuVjguu6Le5WjEEpX67qd9z7jjmc4T/ke3zRUlnDydex9p8ytcwVpMIKcyvjYAQ==
-  dependencies:
-    "@polymer/iron-icon" "^3.0.0-pre.26"
-    "@polymer/iron-iconset-svg" "^3.0.0-pre.26"
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/iron-iconset-svg@^3.0.0", "@polymer/iron-iconset-svg@^3.0.0-pre.26", "@polymer/iron-iconset-svg@^3.0.1":
+"@polymer/iron-iconset-svg@^3.0.0":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@polymer/iron-iconset-svg/-/iron-iconset-svg-3.0.1.tgz#568d6e7dbc120299dae63be3600aeba0d30ddbea"
   integrity sha512-XNwURbNHRw6u2fJe05O5fMYye6GSgDlDqCO+q6K1zAnKIrpgZwf2vTkBd5uCcZwsN0FyCB3mvNZx4jkh85dRDw==


### PR DESCRIPTION
This is a large PR with plenty of room for error. I've tested as much as I can, though please review.

The most notable change was the use of `getIconNames` which isn't present in `vaadin-icon` and had to be brought into `icon-preview.js`

---

https://github.com/conversionxl/aybolit/blob/a5d7ec9bc154c1e314272386af96ae9ef0baa122/packages/storybook/cxl-lumo-styles/icons-preview.js#L109

https://github.com/PolymerElements/iron-iconset-svg/blob/c575f7f30be3174607a76ccf15c16ce4c2416f4c/iron-iconset-svg.js#L102

https://github.com/vaadin/web-components/blob/master/packages/icon/src/vaadin-iconset.js