### PR TITLE
refactor(cxl-lumo-styles): unwrap lets app use large screen estate

### DIFF
--- a/packages/cxl-lumo-styles/scss/_mixins.scss
+++ b/packages/cxl-lumo-styles/scss/_mixins.scss
@@ -29,11 +29,14 @@
   }
 }
 
-@mixin wrap($max-width: var(--cxl-wrap-width, none), $padding: var(--cxl-wrap-padding, none)) {
+@mixin wrap($max-width: false, $padding: var(--cxl-wrap-padding, none)) {
   position: relative;
-  max-width: $max-width;
   padding-right: $padding;
   padding-left: $padding;
   margin-right: auto;
   margin-left: auto;
+
+  @if $max-width {
+    max-width: $max-width;
+  }
 }

--- a/packages/cxl-lumo-styles/scss/_mixins.scss
+++ b/packages/cxl-lumo-styles/scss/_mixins.scss
@@ -29,7 +29,10 @@
   }
 }
 
-@mixin wrap($max-width: false, $padding: var(--cxl-wrap-padding, none)) {
+@mixin wrap(
+  $max-width: var(--cxl-content-max-width-wide, none),
+  $padding: var(--cxl-wrap-padding, none)
+) {
   position: relative;
   padding-right: $padding;
   padding-left: $padding;

--- a/packages/cxl-lumo-styles/scss/global.scss
+++ b/packages/cxl-lumo-styles/scss/global.scss
@@ -3,8 +3,8 @@
 
 html {
   // Variables.
-  --cxl-content-width: 36em;
-  --cxl-wrap-width: 72rem;
+  --cxl-content-max-width: 36em;
+  --cxl-content-max-width-wide: calc(var(--cxl-content-max-width) * 2);
   --cxl-wrap-padding: var(--lumo-space-m);
 
   /**

--- a/packages/cxl-lumo-styles/scss/global.scss
+++ b/packages/cxl-lumo-styles/scss/global.scss
@@ -3,7 +3,7 @@
 
 html {
   // Variables.
-  --cxl-content-max-width: 36em;
+  --cxl-content-max-width: 48em;
   --cxl-content-max-width-wide: calc(var(--cxl-content-max-width) * 2);
   --cxl-wrap-padding: var(--lumo-space-m);
 

--- a/packages/cxl-lumo-styles/scss/themes/vaadin-accordion.scss
+++ b/packages/cxl-lumo-styles/scss/themes/vaadin-accordion.scss
@@ -1,5 +1,5 @@
 :host([theme~="cxl-accordion-card"]) {
   column-gap: calc(var(--lumo-space-m) * 2);
   column-rule: 1px solid var(--lumo-shade-10pct); // match panel `outline`
-  column-width: calc(var(--cxl-wrap-width) / 4);
+  column-width: calc(var(--cxl-content-max-width) / 2);
 }

--- a/packages/cxl-lumo-styles/scss/themes/vaadin-notification-card.scss
+++ b/packages/cxl-lumo-styles/scss/themes/vaadin-notification-card.scss
@@ -1,6 +1,6 @@
 :host([slot^="middle"]),
 [part="overlay"] {
-  max-width: var(--cxl-content-width);
+  max-width: var(--cxl-content-max-width);
 }
 
 :host([theme~="max-w-full"]) [part="overlay"] {

--- a/packages/cxl-ui/scss/cxl-app-layout.scss
+++ b/packages/cxl-ui/scss/cxl-app-layout.scss
@@ -1,6 +1,7 @@
 @use "~@conversionxl/cxl-lumo-styles/scss/mixins";
 @use "cxl-app-layout/layout";
 @use "cxl-app-layout/layout-1c-c";
+@use "cxl-app-layout/layout-1c-w";
 @use "cxl-app-layout/layout-2c";
 @use "cxl-app-layout/layout-2c-r";
 @use "cxl-app-layout/layout-2c-l";

--- a/packages/cxl-ui/scss/cxl-app-layout/_layout-1c-w.scss
+++ b/packages/cxl-ui/scss/cxl-app-layout/_layout-1c-w.scss
@@ -3,12 +3,12 @@
  */
 @use "~@conversionxl/cxl-lumo-styles/scss/mixins";
 
-:host([layout="1c-c"]) {
+:host([layout="1c-w"]) {
   #main {
     // `[wide] #main` flex column item with narrow content doesn't auto-fill x-axis.
     main {
       > slot {
-        max-width: var(--cxl-content-max-width);
+        max-width: var(--cxl-content-max-width-wide);
       }
     }
   }

--- a/packages/cxl-ui/scss/cxl-section.scss
+++ b/packages/cxl-ui/scss/cxl-section.scss
@@ -35,7 +35,7 @@
 .wrap {
   @include mixins.wrap();
 
-  max-width: var(--cxl-content-width);
+  max-width: var(--cxl-content-max-width);
 
   /**
    * Spacious section spacing.
@@ -51,6 +51,6 @@
   }
 
   :host(.alignwide) > & {
-    max-width: var(--cxl-wrap-width);
+    max-width: var(--cxl-content-max-width-wide);
   }
 }

--- a/packages/cxl-ui/scss/global/cxl-app-layout.scss
+++ b/packages/cxl-ui/scss/global/cxl-app-layout.scss
@@ -86,7 +86,7 @@ cxl-app-layout {
     > .entry {
       .entry-content,
       .entry-footer {
-        max-width: var(--cxl-content-width);
+        max-width: var(--cxl-content-max-width);
         margin-right: auto;
         margin-left: auto;
       }

--- a/packages/cxl-ui/scss/global/cxl-vaadin-accordion.scss
+++ b/packages/cxl-ui/scss/global/cxl-vaadin-accordion.scss
@@ -149,7 +149,7 @@ cxl-vaadin-accordion {
   &[theme~="cxl-accordion-playbook-card"] {
     column-gap: calc(var(--lumo-space-m) * 2);
     column-rule: 1px solid var(--lumo-shade-10pct);
-    column-width: calc(var(--cxl-wrap-width) / 4);
+    column-width: calc(var(--cxl-content-max-width) / 2);
 
     vaadin-icon {
       --vaadin-icon-height: var(--lumo-icon-size-s);

--- a/packages/storybook/cxl-ui/cxl-app-layout/layout=1c-c.stories.js
+++ b/packages/storybook/cxl-ui/cxl-app-layout/layout=1c-c.stories.js
@@ -53,4 +53,4 @@ export const CXLAppLayout1cc = () => html`
   </cxl-app-layout>
 `;
 
-CXLAppLayout1cc.storyName = '[layout=1c-c]';
+CXLAppLayout1cc.storyName = '[layout=1c-c] compact';

--- a/packages/storybook/cxl-ui/cxl-app-layout/layout=1c-w.stories.js
+++ b/packages/storybook/cxl-ui/cxl-app-layout/layout=1c-w.stories.js
@@ -37,4 +37,4 @@ export const CXLAppLayout1cw = () => html`
   </cxl-app-layout>
 `;
 
-CXLAppLayout1cw.storyName = '[layout=1c-w]';
+CXLAppLayout1cw.storyName = '[layout=1c-w] wide';

--- a/packages/storybook/cxl-ui/cxl-app-layout/layout=2c-l.stories.js
+++ b/packages/storybook/cxl-ui/cxl-app-layout/layout=2c-l.stories.js
@@ -144,7 +144,7 @@ const Template = ({ hasWidgetBackground, postId, userId, playbookSaved }) => htm
 
 export const CXLAppLayout2cl = Template.bind({});
 
-CXLAppLayout2cl.storyName = '[layout=2c-l]';
+CXLAppLayout2cl.storyName = '[layout=2c-l] content left';
 
 CXLAppLayout2cl.args = {
   postId: 1234,

--- a/packages/storybook/cxl-ui/cxl-app-layout/layout=2c-r.stories.js
+++ b/packages/storybook/cxl-ui/cxl-app-layout/layout=2c-r.stories.js
@@ -384,4 +384,4 @@ export const CXLAppLayout2cr = () => {
   `;
 };
 
-CXLAppLayout2cr.storyName = '[layout=2c-r]';
+CXLAppLayout2cr.storyName = '[layout=2c-r] content right';

--- a/packages/storybook/cxl-ui/cxl-tabs-slider/cxl-tabs-slider.stories.js
+++ b/packages/storybook/cxl-ui/cxl-tabs-slider/cxl-tabs-slider.stories.js
@@ -11,7 +11,7 @@ export default {
 export const CXLTabsSlider = ({ Cards }) => html`
   <style>
     vaadin-tab {
-      max-width: calc(var(--cxl-content-width) / 2);
+      max-width: calc(var(--cxl-content-max-width) / 2);
     }
   </style>
 

--- a/packages/storybook/cxl-ui/footer-nav.stories.js
+++ b/packages/storybook/cxl-ui/footer-nav.stories.js
@@ -16,7 +16,6 @@ export const CXLFooterNav = () => html`
     }
 
     .site-footer .menu > .wrap {
-      max-width: unset;
       padding-bottom: var(--lumo-space-xl);
       padding-top: var(--lumo-space-xl);
     }

--- a/packages/storybook/cxl-ui/footer-nav.stories.js
+++ b/packages/storybook/cxl-ui/footer-nav.stories.js
@@ -16,6 +16,7 @@ export const CXLFooterNav = () => html`
     }
 
     .site-footer .menu > .wrap {
+      max-width: unset;
       padding-bottom: var(--lumo-space-xl);
       padding-top: var(--lumo-space-xl);
     }


### PR DESCRIPTION
Re-orient from `--cxl-wrap-width` to `--cxl-content-max-width`, communicates intent clearer.

Will probably require some refactor in app CSS.

**1080p BEFORE**
![image](https://user-images.githubusercontent.com/147228/218309448-db583e26-7675-47d6-b031-db48ffe429ca.png)


**1080p AFTER**
![image](https://user-images.githubusercontent.com/147228/218309389-3cdb4170-81b2-4e23-b794-a0c29e113837.png)
