### PR TITLE
feat(cxl-ui): [cxl-vaadin-accordion] add simple attribute to disable state restoration

### DIFF
--- a/packages/cxl-ui/src/components/cxl-vaadin-accordion.js
+++ b/packages/cxl-ui/src/components/cxl-vaadin-accordion.js
@@ -11,6 +11,13 @@ import cxlVaadinAccordionGlobalStyles from '../styles/global/cxl-vaadin-accordio
  */
 @customElement('cxl-vaadin-accordion')
 export class CXLVaadinAccordionElement extends Accordion {
+  static get properties() {
+    return {
+      ...super.properties,
+      simple: { observer: '_simpleChanged', type: Boolean },
+    };
+  }
+
   /**
    * Global styles.
    */
@@ -22,8 +29,20 @@ export class CXLVaadinAccordionElement extends Accordion {
     });
   }
 
+  // Observe the the `simple` attribute and close or restore accordion panels.
+  _simpleChanged(newValue) {
+    if (newValue) {
+      this.opened = null;
+    } else {
+      this.hasAppliedState = false;
+      this._updateItems(this.items, this.opened);
+    }
+  }
+
   // Keep track of accordion panels state.
   _updateOpened(e) {
+    if (this.simple) return;
+
     const target = this._filterItems(e.composedPath())[0];
     const idx = this.items.indexOf(target);
 
@@ -43,6 +62,9 @@ export class CXLVaadinAccordionElement extends Accordion {
   // Restore accordion panel state.
   _updateItems(items, opened) {
     if (!items) {
+      return;
+    } else if (this.simple) {
+      super._updateItems(items, opened);
       return;
     }
 

--- a/packages/storybook/cxl-ui/cxl-vaadin-accordion/cxl-accordion-card.story.js
+++ b/packages/storybook/cxl-ui/cxl-vaadin-accordion/cxl-accordion-card.story.js
@@ -5,7 +5,7 @@ import '@conversionxl/cxl-ui/src/components/cxl-accordion-card.js';
 import '@conversionxl/cxl-ui/src/components/cxl-save-favorite.js';
 import archiveData from './theme=cxl-archive.data.json';
 
-export const CXLVaadinAccordionThemeArchive = () => {
+export const CXLVaadinAccordionThemeArchive = ({ simple }) => {
   let lastEntryTitle1stLetter = 'Z';
 
   const firstLetterHeading = (el) => {
@@ -43,6 +43,7 @@ export const CXLVaadinAccordionThemeArchive = () => {
     <cxl-vaadin-accordion
       id="cxl-vaadin-accordion-26107"
       class="archive archive-certificate plural"
+      ?simple=${simple}
       theme="cxl-accordion-card"
     >
       ${archiveData.map(
@@ -103,4 +104,8 @@ export const CXLVaadinAccordionThemeArchive = () => {
       )}
     </cxl-vaadin-accordion>
   `;
+};
+
+CXLVaadinAccordionThemeArchive.args = {
+  simple: false,
 };


### PR DESCRIPTION
https://app.clickup.com/t/861mma51g

Adding the `simple` attribute disables state restoration:

```
<cxl-vaadin-accordion simple></cxl-vaadin-accordion>
```