### PR TITLE
refactor(cxl-ui): add cxlBaseCardElement as base class

### DIFF
--- a/packages/cxl-ui/scss/cxl-base-card.scss
+++ b/packages/cxl-ui/scss/cxl-base-card.scss
@@ -1,0 +1,170 @@
+/* stylelint-disable value-no-vendor-prefix, property-no-vendor-prefix -- some of these are necessary for line-clamp implementation */
+@use "~@conversionxl/cxl-lumo-styles/scss/mq";
+
+:host {
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  width: 100%;
+  max-width: calc(100% - 2 * var(--lumo-space-l));
+  height: max-content;
+  min-height: 270px;
+  padding: var(--lumo-space-m) var(--lumo-space-l);
+  font-size: var(--lumo-font-size-s);
+  background: var(--lumo-tint);
+  border: 1px solid var(--lumo-contrast-10pct);
+  border-radius: var(--lumo-border-radius-l);
+  box-shadow: var(--lumo-box-shadow-xs);
+  break-inside: avoid;
+  transform: translateZ(0); // CSS columns @see https://stackoverflow.com/a/55110789/35946
+
+  // @see https://github.com/conversionxl/aybolit/pull/293
+  --video-background: hsla(355.8, 74.7%, 48%, 0.03); // --lumo-primary-color-3pct does not exist
+  --training-background: hsla(0, 0%, 10%, 0.03); // --lumo-shade-3pct does not exist
+  --playbook-background: hsla(213, 100%, 62%, 0.03); // No similar base color exists
+
+  // Container / Media queries
+  @media #{mq.$small} {
+    max-width: unset;
+    margin: unset;
+
+    .container > .attributes {
+      display: none;
+    }
+
+    header .info .attributes {
+      display: flex;
+    }
+  }
+
+  [empty] {
+    visibility: hidden;
+    user-select: none;
+  }
+}
+
+:host([hidden]) {
+  display: none;
+}
+
+:host(:first-child) {
+  margin-top: unset;
+}
+
+:host(:last-child) {
+  margin-bottom: unset;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--lumo-space-s);
+  width: 100%;
+  transition: all 0.3s ease;
+
+  > .attributes {
+    padding-top: 0;
+  }
+
+  footer {
+    margin-top: var(--lumo-space-s);
+  }
+}
+
+.tags {
+  display: flex;
+  gap: var(--lumo-space-s);
+  max-width: 100%;
+  min-height: 1.6em;
+}
+
+.attributes {
+  display: flex;
+  align-items: flex-start;
+  align-self: stretch;
+  padding: var(--lumo-space-s) 0;
+  gap: var(--lumo-space-m);
+  color: var(--lumo-shade-60pct);
+}
+
+header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: var(--lumo-space-m);
+
+  .info {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--lumo-space-xs);
+    align-self: stretch;
+    max-width: calc(100% - var(--lumo-space-m) - 80px);
+    overflow: hidden;
+
+    .name {
+      font-family: var(--lumo-font-family);
+      font-size: var(--lumo-font-size-xl);
+      font-style: normal;
+      font-weight: 700;
+      line-height: var(--lumo-line-height-xs);
+      color: #1a1a1a;
+    }
+
+    .attributes {
+      display: none;
+    }
+
+    .tags {
+      flex-wrap: nowrap;
+
+      ::slotted(.tag),
+      .tag:not(:first-child):not(.new) {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .tag {
+        &:first-child,
+        &.new {
+          color: var(--lumo-primary-color);
+        }
+
+        &:first-child {
+          text-transform: capitalize;
+        }
+      }
+    }
+  }
+
+  .instructor-image {
+    width: 80px;
+    height: 92px;
+
+    img {
+      height: 80px;
+      overflow: hidden;
+      border-radius: 100px;
+    }
+  }
+}
+
+.badge-new {
+  display: none;
+}
+
+:host([new]) {
+  .badge-new {
+    position: absolute;
+    top: calc(-1 * var(--lumo-space-s));
+    right: calc(-1 * var(--lumo-space-s));
+    display: block;
+    width: calc(2 * var(--lumo-space-m));
+    height: calc(2 * var(--lumo-space-m));
+    padding: 6px;
+    color: var(--lumo-primary-contrast-color);
+    background: var(--lumo-primary-color);
+    border-radius: 100%;
+  }
+}

--- a/packages/cxl-ui/scss/cxl-course-card.scss
+++ b/packages/cxl-ui/scss/cxl-course-card.scss
@@ -1,59 +1,4 @@
 /* stylelint-disable value-no-vendor-prefix, property-no-vendor-prefix -- some of these are necessary for line-clamp implementation */
-@use "~@conversionxl/cxl-lumo-styles/scss/mq";
-
-:host {
-  position: relative;
-  box-sizing: border-box;
-  display: flex;
-  height: max-content;
-  max-width: calc(100% - 2 * var(--lumo-space-l));
-  width: 100%;
-  min-height: 270px;
-  padding: var(--lumo-space-m) var(--lumo-space-l);
-  font-size: var(--lumo-font-size-s);
-  background: var(--lumo-tint);
-  border: 1px solid var(--lumo-contrast-10pct);
-  border-radius: var(--lumo-border-radius-l);
-  box-shadow: var(--lumo-box-shadow-xs);
-  break-inside: avoid;
-  transform: translateZ(0); // CSS columns @see https://stackoverflow.com/a/55110789/35946
-
-  // @see https://github.com/conversionxl/aybolit/pull/293
-  --video-background: hsla(355.8, 74.7%, 48%, 0.03); // --lumo-primary-color-3pct does not exist
-  --training-background: hsla(0, 0%, 10%, 0.03); // --lumo-shade-3pct does not exist
-  --playbook-background: hsla(213, 100%, 62%, 0.03); // No similar base color exists
-
-  // Container / Media queries
-  @media #{mq.$small} {
-    margin: unset;
-    max-width: unset;
-
-    .container > .attributes {
-      display: none;
-    }
-
-    header .info .attributes {
-      display: flex;
-    }
-  }
-
-  [empty] {
-    visibility: hidden;
-    user-select: none;
-  }
-}
-
-:host([hidden]) {
-  display: none;
-}
-
-:host(:first-child) {
-  margin-top: unset;
-}
-
-:host(:last-child) {
-  margin-bottom: unset;
-}
 
 :host([theme~="dark"]) {
   background-color: var(--lumo-contrast);
@@ -71,111 +16,20 @@
   background-color: var(--playbook-background);
 }
 
-.container {
-  display: flex;
-  flex-direction: column;
-  gap: var(--lumo-space-s);
-  width: 100%;
-  transition: all 0.3s ease;
-
-  > .attributes {
-    padding-top: 0;
-  }
-
-  .content-wrapper, footer {
-    margin-top: var(--lumo-space-s);
-  }
-}
-
-.tags {
-  display: flex;
-  gap: var(--lumo-space-s);
-  min-height: 1.6em;
-  max-width: 100%;
-}
-
-.attributes {
-  display: flex;
-  align-items: flex-start;
-  align-self: stretch;
-  padding: var(--lumo-space-s) 0;
-  gap: var(--lumo-space-s);
-  color: var(--lumo-shade-60pct);
-}
-
-header {
-  display: flex;
-  align-items: start;
-  justify-content: space-between;
-  gap: var(--lumo-space-m);
-
-  .info {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: var(--lumo-space-xs);
-    align-self: stretch;
-    max-width: calc(100% - var(--lumo-space-m) - 80px);
-    overflow: hidden;
-
-    .name {
-      font-family: Roboto, sans-serif;
-      font-size: var(--lumo-font-size-xl);
-      font-style: normal;
-      font-weight: 700;
-      line-height: var(--lumo-line-height-xs);
-      color: #1A1A1A;
-    }
-
-    .attributes {
-      display: none;
-    }
-
-    .tags {
-      flex-wrap: nowrap;
-
-      ::slotted(.tag), .tag:not(:first-child):not(.new) {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-
-      .tag {
-        &:first-child, &.new {
-          color: var(--lumo-primary-color)
-        }
-
-        &:first-child {
-          text-transform: capitalize;
-        }
-      }
-    }
-  }
-
-  .instructor-image {
-    width: 80px;
-    height: 92px;
-
-    img {
-      height: 80px;
-      overflow: hidden;
-      border-radius: 100px;
-    }
-  }
-}
-
 .content-wrapper {
   min-height: calc(var(--lumo-line-height-s) * 6); // Six standard line-heights
   line-height: var(--lumo-line-height-s);
 
   .content {
-    min-height: calc(var(--lumo-line-height-s) * 3 + 1.25em); // Four standard line-heights plus global inherited <p> block margins
+    min-height: calc(
+      var(--lumo-line-height-s) * 3 + 1.25em
+    ); // Four standard line-heights plus global inherited <p> block margins
   }
 
   .tags {
+    flex-wrap: wrap;
     margin-top: var(--lumo-space-s);
     transition: height 0.3s ease-in-out;
-    flex-wrap: wrap;
 
     ::slotted(span) {
       font-style: italic;
@@ -231,24 +85,5 @@ footer {
       background: var(--lumo-primary-color-10pct);
       border-radius: 100%;
     }
-  }
-}
-
-.badge-new {
-  display: none;
-}
-
-:host([new]) {
-  .badge-new {
-    position: absolute;
-    top: calc(-1 * var(--lumo-space-s));
-    right: calc(-1 * var(--lumo-space-s));
-    display: block;
-    width: calc(2 * var(--lumo-space-m));
-    height: calc(2 * var(--lumo-space-m));
-    padding: 6px;
-    color: var(--lumo-primary-contrast-color);
-    background: var(--lumo-primary-color);
-    border-radius: 100%;
   }
 }

--- a/packages/cxl-ui/scss/cxl-time.scss
+++ b/packages/cxl-ui/scss/cxl-time.scss
@@ -1,0 +1,5 @@
+:host {
+  display: flex;
+  gap: var(--lumo-space-xs);
+  color: var(--lumo-shade-60pct);
+}

--- a/packages/cxl-ui/src/components/cxl-base-card.js
+++ b/packages/cxl-ui/src/components/cxl-base-card.js
@@ -1,0 +1,90 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { LitElement, html } from 'lit';
+import { property, state } from 'lit/decorators.js';
+import '@vaadin/details';
+import '@vaadin/button';
+import './cxl-time.js';
+import cxlBaseCardStyles from '../styles/cxl-base-card-css.js';
+
+export class CXLBaseCardElement extends LitElement {
+  static get styles() {
+    return [cxlBaseCardStyles];
+  }
+
+  separator = html`<span> | </span>`;
+
+  @state() _tagsHasChildren = false;
+
+  @property({ type: String }) id = '';
+
+  @property({ type: String }) theme = '';
+
+  @property({ type: String }) name = '';
+
+  @property({ type: String }) time = '';
+
+  @property({ type: String }) instructor = '';
+
+  @property({ type: String }) avatar = '';
+
+  @property({ type: Boolean }) showTags = true;
+
+  @property({ type: Boolean, reflect: true }) new = false;
+
+  _slotHasChildren(e) {
+    const slot = e.target;
+    const { name } = slot;
+    const children = slot.assignedNodes();
+    this[`_${name}HasChildren`] = !!children.length;
+  }
+
+  _renderHeaderTags() {
+    return html`
+      <div class="tags">
+        ${this.theme ? html`<span class="tag">${this.theme}</span>` : ''}
+        ${this.theme && this._tagsHasChildren ? this.separator : ''}
+        <slot name="tags" @slotchange=${this._slotHasChildren}></slot>
+        ${this.new ? html`${this.theme ? this.separator : ''}<span class="tag new">NEW</span>` : ''}
+      </div>
+    `;
+  }
+
+  _renderHeaderName() {
+    return html` <div class="name">${this.name}</div> `;
+  }
+
+  _renderHeaderAttributes() {
+    return html`
+      <div class="attributes">
+        <cxl-time
+          time=${this.time}
+          ?show-icon=${!!(this.theme.toLowerCase() === 'course')}
+        ></cxl-time>
+        <div class="instructor">By: ${this.instructor}</div>
+      </div>
+    `;
+  }
+
+  _renderAvatar() {
+    return html` <img src=${this.avatar} alt="${this.instructor}" /> `;
+  }
+
+  /**
+   * Renders the header of the component. Note that _renderHeaderAttributes is
+   * called in two places, inside and after header, to accomodate to
+   * responsiveness of the component on very narrow containers, handled in CSS
+   * @return {string} The rendered header HTML.
+   */
+  _renderHeader() {
+    return html`
+      <header>
+        <div class="info">
+          ${this.showTags ? this._renderHeaderTags() : ''} ${this._renderHeaderName()}
+          ${this._renderHeaderAttributes()}
+        </div>
+        <div class="instructor-image">${this._renderAvatar()}</div>
+      </header>
+      ${this._renderHeaderAttributes()}
+    `;
+  }
+}

--- a/packages/cxl-ui/src/components/cxl-course-card.js
+++ b/packages/cxl-ui/src/components/cxl-course-card.js
@@ -1,92 +1,39 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { LitElement, html } from 'lit';
+import { html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import '@vaadin/details';
 import '@vaadin/button';
 import cxlCourseCardStyles from '../styles/cxl-course-card-css.js';
+import { CXLBaseCardElement } from './cxl-base-card.js';
 
 @customElement('cxl-course-card')
-export class CXLCourseCardElement extends LitElement {
+export class CXLCourseCardElement extends CXLBaseCardElement {
   static get styles() {
-    return [cxlCourseCardStyles];
+    return [...super.styles, cxlCourseCardStyles];
   }
 
-  separator = html`<span> | </span>`;
-
-  @state() _tagsHasChildren = false;
-
   @state() _moreHasChildren = false;
-
-  @property({ type: String }) id = '';
-
-  @property({ type: String }) theme = 'course';
-
-  @property({ type: String }) name = '';
-
-  @property({ type: String }) time = '';
-
-  @property({ type: String }) instructor = '';
-
-  @property({ type: String }) avatar = '';
-
-  @property({ type: Boolean, reflect: true }) new = false;
 
   @property({ type: String, attribute: 'cta-label' }) ctaLabel = 'View';
 
   @property({ type: String, attribute: 'cta-url' }) ctaUrl = '';
 
-  _slotHasChildren (e) {
-    const slot = e.target
-    const { name } = slot
-    const children = slot.assignedNodes()
-    this[`_${name}HasChildren`] = !!children.length
+  _slotHasChildren(e) {
+    const slot = e.target;
+    const { name } = slot;
+    const children = slot.assignedNodes();
+    this[`_${name}HasChildren`] = !!children.length;
   }
 
   render() {
     return html`
       <div class="container">
-        <header>
-          <div class="info">
-            <div class="tags">
-              ${this.theme ? html`<span class="tag">${this.theme}</span>`: ''}
-              ${this.theme && this._tagsHasChildren ? this.separator : ''}
-              <slot name="tags" @slotchange=${this._slotHasChildren}></slot>
-              ${this.new ? html`${this.theme ? this.separator : ''}<span class="tag new">NEW</span>` : '' }
-            </div>
-            <div class="name">
-              ${this.name}
-            </div>
-            <div class="attributes">
-              <div class="time">
-                ${this.theme.toLowerCase() === 'course' ? html`<vaadin-icon icon="lumo:clock"></vaadin-icon>` : ''}
-                ${this.time}
-              </div>
-              <div class="instructor">
-                By: ${this.instructor}
-              </div>
-            </div>
-          </div>
-          <div class="instructor-image">
-            <img
-              src=${this.avatar}
-              alt="${this.instructor}"
-            />
-          </div>
-        </header>
-        <div class="attributes">
-          <div class="time">
-            ${this.theme.toLowerCase() === 'course' ? html`<vaadin-icon icon="lumo:clock"></vaadin-icon>` : ''}
-            ${this.time}
-          </div>
-          <div class="instructor">
-            By: ${this.instructor}
-          </div>
-        </div>
+        ${this._renderHeader()}
         <section class="content-wrapper">
           <div class="content">
             <slot name="content"></slot>
           </div>
-          <div class="tags" >
+          <div class="tags">
             <slot name="content-tags"></slot>
           </div>
         </section>

--- a/packages/cxl-ui/src/components/cxl-time.js
+++ b/packages/cxl-ui/src/components/cxl-time.js
@@ -1,0 +1,21 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import cxlTimeStyles from '../styles/cxl-time-css.js';
+
+@customElement('cxl-time')
+export class CxlTime extends LitElement {
+  static get styles() {
+    return [cxlTimeStyles];
+  }
+
+  @property({ type: String }) time = '';
+
+  @property({ type: Boolean, attribute: 'show-icon' }) showIcon = false;
+
+  render() {
+    return html`
+      ${this.showIcon ? html`<vaadin-icon icon="lumo:clock"></vaadin-icon>` : ''} ${this.time}
+    `;
+  }
+}

--- a/packages/storybook/cxl-ui/cxl-time.stories.js
+++ b/packages/storybook/cxl-ui/cxl-time.stories.js
@@ -1,0 +1,19 @@
+import { html } from 'lit';
+import '@conversionxl/cxl-ui/src/components/cxl-time.js';
+
+export default {
+  title: 'CXL UI/cxl-time',
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export const CXLTime = ({ time, showIcon }) => html`
+  <cxl-time time=${time} ?show-icon=${showIcon}></cxl-time>
+`;
+
+CXLTime.storyName = 'cxl-time';
+CXLTime.args = {
+  time: '02h 45min',
+  showIcon: true,
+};


### PR DESCRIPTION
Tasks: 
- https://app.clickup.com/t/862k6unkf
- https://app.clickup.com/t/862k77fbg

The new cxlBaseCard class should be used for all CXL 2.0 course cards. It does not register as a customElement, so it needs to be extended by new target classes. As implemented here, `cxl-course-card` is complete, while `cxl-feature-course-card` and `cxl-light-card` should only need some additional CSS.  