### PR TITLE
fix(cxl-ui): remove bad usage of storybook stories in component class

### DIFF
--- a/packages/cxl-ui/src/components/cxl-dashboard-header.js
+++ b/packages/cxl-ui/src/components/cxl-dashboard-header.js
@@ -3,11 +3,10 @@ import { LitElement, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import '@conversionxl/cxl-lumo-styles';
 import '@vaadin/progress-bar';
+import './cxl-dashboard-notification';
 import { registerGlobalStyles } from '@conversionxl/cxl-lumo-styles/src/utils';
 import cxlDashboardHeaderGlobalStyles from '../styles/global/cxl-dashboard-header-css.js';
 import cxlDashboardHeaderStyles from '../styles/cxl-dashboard-header-css.js';
-import { CXLDashboardNotification } from '../../../storybook/cxl-ui/cxl-dashboard-notification/default.stories.js';
-import notificationData from '../../../storybook/cxl-ui/cxl-dashboard-notification/cxl-dashboard-notification.data.json';
 
 @customElement('cxl-dashboard-header')
 export class CXLDashboardHeaderElement extends LitElement {
@@ -91,10 +90,10 @@ export class CXLDashboardHeaderElement extends LitElement {
         <header>
           ${this.notificationCount > 0
             ? html`<div class="updates">
-                ${CXLDashboardNotification(CXLDashboardNotification.args = {
-                  count: this.notificationCount,
-                  tabs: this.notificationData || notificationData
-                })}
+                <cxl-dashboard-notification
+                  count="${this.notificationCount}"
+                  .tabs=${this.notificationData}
+                ></cxl-dashboard-notification>
               </div>`
             : ''}
           <div>
@@ -115,8 +114,10 @@ export class CXLDashboardHeaderElement extends LitElement {
                 <vaadin-icon icon="lumo:arrow-right"></vaadin-icon>
               </vaadin-button>
               ${!this.hasRoadmap
-                ? html`
-                  <vaadin-button class="roadmap" onclick="window.location.href='${this.cta3Link}'">
+                ? html` <vaadin-button
+                    class="roadmap"
+                    onclick="window.location.href='${this.cta3Link}'"
+                  >
                     ${this.cta3}
                     <vaadin-icon icon="lumo:arrow-right"></vaadin-icon>
                   </vaadin-button>`

--- a/packages/cxl-ui/src/components/cxl-dashboard-notification.js
+++ b/packages/cxl-ui/src/components/cxl-dashboard-notification.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 /* eslint-disable import/no-extraneous-dependencies */
 import { LitElement, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
@@ -39,7 +40,7 @@ export class CXLDashboardNotificationElement extends LitElement {
   _onTabSelected(e) {
     const selectedTabIndex = e.detail.value;
     const selectedTabId = `tab-${selectedTabIndex + 1}`;
-    this.shadowRoot.querySelectorAll('[data-tab]').forEach(tabContent => {
+    this.shadowRoot.querySelectorAll('[data-tab]').forEach((tabContent) => {
       tabContent.hidden = tabContent.getAttribute('data-tab') !== selectedTabId;
     });
   }
@@ -59,35 +60,51 @@ export class CXLDashboardNotificationElement extends LitElement {
           <vaadin-icon icon="lumo:angle-right" class="icon-arrow"></vaadin-icon>
         </vaadin-button>
         <div class="tabs-wrapper">
-          <vaadin-tabs slot="tabs" theme="cxl-dashboard-notification" @selected-changed="${this._onTabSelected}">
-            ${this.tabs.map(tab => html`
-              <vaadin-tab id="${tab.id}" theme="cxl-dashboard-notification">
-                ${tab.title}
-              </vaadin-tab>
-            `)}
+          <vaadin-tabs
+            slot="tabs"
+            theme="cxl-dashboard-notification"
+            @selected-changed="${this._onTabSelected}"
+          >
+            ${this.tabs?.map(
+              (tab) => html`
+                <vaadin-tab id="${tab.id}" theme="cxl-dashboard-notification">
+                  ${tab.title}
+                </vaadin-tab>
+              `
+            )}
           </vaadin-tabs>
-          ${this.tabs.map(tab => html`
-            <div data-tab="${tab.id}" hidden>
-              ${tab.groups ? tab.groups.map(group => html`
-                <div class="tab-title">${group.title} ${group.count ? `(${group.count})` : ''}</div>
-                <div class="tab-items">
-                  ${group.cards.map(card => html`
-                    <cxl-notification-card
-                      id="${card.id}"
-                      theme="${card.theme}"
-                      title="${card.title}"
-                      time="${card.time}"
-                      avatar="${card.avatar}"
-                      link="${card.link}"
-                      .new="${card.new}"
-                      .edited="${card.edited}"
-                    >
-                    </cxl-notification-card>
-                  `)}
-                </div>
-              `) : html`<div class="no-updates">${this.noUpdates}</div>`}
-            </div>
-          `)}
+          ${this.tabs?.map(
+            (tab) => html`
+              <div data-tab="${tab.id}" hidden>
+                ${tab.groups
+                  ? tab.groups.map(
+                      (group) => html`
+                        <div class="tab-title">
+                          ${group.title} ${group.count ? `(${group.count})` : ''}
+                        </div>
+                        <div class="tab-items">
+                          ${group.cards.map(
+                            (card) => html`
+                              <cxl-notification-card
+                                id="${card.id}"
+                                theme="${card.theme}"
+                                title="${card.title}"
+                                time="${card.time}"
+                                avatar="${card.avatar}"
+                                link="${card.link}"
+                                .new="${card.new}"
+                                .edited="${card.edited}"
+                              >
+                              </cxl-notification-card>
+                            `
+                          )}
+                        </div>
+                      `
+                    )
+                  : html`<div class="no-updates">${this.noUpdates}</div>`}
+              </div>
+            `
+          )}
         </div>
       </vaadin-details>
     `;

--- a/packages/storybook/cxl-ui/cxl-dashboard-header/template.stories.js
+++ b/packages/storybook/cxl-ui/cxl-dashboard-header/template.stories.js
@@ -4,6 +4,7 @@ import '@conversionxl/cxl-lumo-styles';
 import '@conversionxl/cxl-ui/src/components/cxl-dashboard-header.js';
 import statsData from '../cxl-stats/theme=cxl-dashboard-header.data.json';
 import '../../../cxl-ui/src/components/cxl-stats';
+import notificationData from '../cxl-dashboard-notification/cxl-dashboard-notification.data.json';
 
 export default {
   title: 'CXL UI/cxl-dashboard-header',
@@ -14,6 +15,7 @@ const Template = (header) => html`
     theme="cxl-dashboard-header"
     name=${header.name}
     notification-count=${header.notificationCount}
+    .notificationData=${notificationData}
     last-course-title=${header.lastCourseTitle}
     last-course-link=${header.lastCourseLink}
     progress=${header.progress}


### PR DESCRIPTION
This was not part of the sprint, but an issue identified while working on a different task. 

The component `cxl-dashboard-header` was importing `cxl-dashboard-notification` **storybook** code and example data to use inside the elements template, seemingly instead of importing and using the actual element. I'm not sure what was the idea behind it, but it's 100% incorrect usage of both custom elements and stories, so I decided to preemptively correct it. 
The updated code was tested in storybook and local wp starter environment.