### PR TITLE
fix(cxl-lumo-styles): cxl-marketing-nav submenu not opening on tall mobile a9818ad

### DIFF
--- a/packages/cxl-lumo-styles/scss/themes/vaadin-overlay.scss
+++ b/packages/cxl-lumo-styles/scss/themes/vaadin-overlay.scss
@@ -50,7 +50,7 @@
   padding-left: 0;
 }
 
-@media (min-width: 768px), (min-height: 768px) {
+@media (min-width: 768px), (min-height: 768px) and (orientation: landscape) {
   :host([theme~="cxl-marketing-nav"]) {
     position: relative;
     top: 0 !important; /* stylelint-disable-line declaration-no-important */


### PR DESCRIPTION
🚀  Already live

Submenu was not opening on tall (> 768px) mobile devices.

https://cxlworld.slack.com/archives/C01JABH8AHX/p1697400946534649

![image](https://github.com/conversionxl/aybolit/assets/5165721/79d1c55e-7c47-492b-b465-c1d42287a496)
