### PR TITLE
fix(cxl-ui): fix wrong nav overlays-wrapper height

### DIFF
--- a/packages/cxl-ui/src/components/cxl-marketing-nav.js
+++ b/packages/cxl-ui/src/components/cxl-marketing-nav.js
@@ -297,10 +297,13 @@ export class CXLMarketingNavElement extends LitElement {
       const firstOverlay = overlays[0];
 
       if (this.overlaysWrapperElement) {
-        this.overlaysWrapperElement.style.maxHeight = `${
-          window.innerHeight -
-          (this.overlaysWrapperElement.style?.maxHeight || firstOverlay.offsetTop)
-        }px`;
+        if (overlays.length > 1) {
+          const heightOffset =
+            this.overlaysWrapperElement.style?.maxHeight || firstOverlay.offsetTop;
+          this.overlaysWrapperElement.style.maxHeight = `${
+            window.innerHeight - (heightOffset || 0)
+          }px`;
+        }
 
         this.overlaysWrapperElement.appendChild(overlay);
         this.overlaysWrapperElement.toggleAttribute('hidden', false);


### PR DESCRIPTION
https://app.clickup.com/t/86ayaanv9

Fixes empty menu bugs in some pages. Due to a timing issue, the menu overlays wrapper can get a maxHeight set to 0, preventing menu lists from showing the items.  