### PR TITLE
fix(cxl-ui): context-menu does not close on outside click

### DIFF
--- a/packages/cxl-ui/src/components/cxl-marketing-nav.js
+++ b/packages/cxl-ui/src/components/cxl-marketing-nav.js
@@ -288,6 +288,8 @@ export class CXLMarketingNavElement extends LitElement {
    */
   _onOverlayOpen(e) {
     const overlay = e.target;
+    if (overlay.getAttribute('theme').indexOf('cxl-marketing-nav') === -1) return;
+
     overlay.addEventListener('opened-changed', this._onOverlayClose.bind(this));
 
     if (window.matchMedia(this._wideMediaQuery).matches) {


### PR DESCRIPTION
Fixes lesson action bar `vaadin-context-menu` not closing on outside click

related: https://github.com/conversionxl/cxl-wpstarter/pull/264