### PR TITLE
fix(cxl-lumo-styles): limit secondary font style in ul to .entry-content

### DIFF
--- a/packages/cxl-lumo-styles/scss/global.scss
+++ b/packages/cxl-lumo-styles/scss/global.scss
@@ -127,7 +127,10 @@ img {
 ol,
 ul {
   padding-left: var(--lumo-space-l);
-  font-family: var(--cxl-lumo-font-secondary);
+
+  .entry-content & {
+    font-family: var(--cxl-lumo-font-secondary);
+  }
 }
 
 /**


### PR DESCRIPTION
As requested in [cxl-wpstarter PR](https://github.com/conversionxl/cxl-wpstarter/pull/283#pullrequestreview-1757302024)

Tested locally:

![Screenshot from 2023-11-30 11-19-55](https://github.com/conversionxl/aybolit/assets/1887825/5a7110fe-cd07-4e02-bab6-4b83e1424639)
![Screenshot from 2023-11-30 11-20-29](https://github.com/conversionxl/aybolit/assets/1887825/1b954a79-4f43-416a-acce-67b5bff8334b)
