### PR TITLE
feat(cxl-ui): cxl-marketing-nav open Intercom for .menu-item-help

### DIFF
--- a/packages/cxl-ui/src/components/cxl-marketing-nav.js
+++ b/packages/cxl-ui/src/components/cxl-marketing-nav.js
@@ -286,6 +286,12 @@ export class CXLMarketingNavElement extends LitElement {
       if (classes?.includes('menu-item-search')) {
         menuItemElement.addEventListener('click', this.toggleSearchDialog.bind(this));
       }
+
+      if (classes?.includes('menu-item-help')) {
+        menuItemElement.addEventListener('click', () => {
+          Intercom('show');
+        });
+      }
     }
 
     // Add prefix icon.


### PR DESCRIPTION
Open Intercom chat widget when user clicks on the menu item with `.menu-item-help` class.