### PR TITLE
refactor(cxl-ui): cxl-star-rating remove _updateReadonlyAndValue

### DIFF
--- a/packages/cxl-ui/src/components/cxl-star-rating.js
+++ b/packages/cxl-ui/src/components/cxl-star-rating.js
@@ -124,9 +124,6 @@ export class CXLStarRatingElement extends LitElement {
       this.setAttribute('readonly', 'true');
       return;
     }
-
-    this._saveState(value);
-    this._updateReadonlyAndValue();
   }
 
   _starClicked(e, value) {


### PR DESCRIPTION
This is necessary to prevent the component from saving default value on each usage case.
We prefer it being zero at all times.

https://app.clickup.com/t/86azy6kx9?comment=90140034479841&threadedComment=90140035014093