### PR TITLE
fix(cxl-lumo-styles): button size progression, text wrap, and secondary contrast

### DIFF
--- a/packages/cxl-lumo-styles/scss/block-editor/button.scss
+++ b/packages/cxl-lumo-styles/scss/block-editor/button.scss
@@ -2,7 +2,7 @@
     /* Sizing */
     --lumo-button-size: var(--lumo-size-m);
     min-width: var(--vaadin-button-min-width, calc(var(--_button-size) * 2));
-    height: var(--_button-size);
+    min-height: var(--_button-size);
     padding: var(--vaadin-button-padding, 0 calc(var(--_button-size) / 3 + var(--lumo-border-radius-m) / 2));
     margin: var(--vaadin-button-margin, var(--lumo-space-xs) 0);
     box-sizing: border-box;
@@ -73,9 +73,8 @@
   }
 
   &.x-large {
-    --lumo-button-size: calc(var(--lumo-size-xl) * 1.25);
-    padding: 1.25em 3.5em 1.25em 3em;
-    font-size: calc(var(--lumo-font-size-xxxl) / 2) !important;
+    --lumo-button-size: var(--lumo-size-xl);
+    font-size: var(--lumo-font-size-xl) !important;
   }
 
   .wp-block-button__link {

--- a/packages/cxl-lumo-styles/scss/themes/vaadin-button.scss
+++ b/packages/cxl-lumo-styles/scss/themes/vaadin-button.scss
@@ -1,8 +1,13 @@
-:host([theme="x-large"]), :host(.cxl-homepage-button) {
-  --lumo-button-size: calc(var(--lumo-size-xl) * 1.25);
+:host([theme~="x-large"]), :host(.cxl-homepage-button) {
+  --lumo-button-size: var(--lumo-size-xl);
   cursor: pointer;
-  padding: 1.25em 3.5em 1.25em 3em;
-  font-size: calc(var(--lumo-font-size-xxxl) / 2) !important;
+  font-size: var(--lumo-font-size-xl) !important;
+}
+
+:host(.wp-block-button) [part="label"] {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: unset;
 }
 
 :host(.wide) {
@@ -41,4 +46,9 @@
 :host([theme~="secondary"]) {
   background-color: var(--lumo-base-color);
   color: var(--lumo-contrast);
+}
+
+:host([theme~="secondary"][theme~="contrast"]) {
+  background-color: var(--lumo-contrast);
+  color: var(--lumo-base-color);
 }

--- a/packages/cxl-lumo-styles/scss/themes/vaadin-button.scss
+++ b/packages/cxl-lumo-styles/scss/themes/vaadin-button.scss
@@ -4,10 +4,20 @@
   font-size: var(--lumo-font-size-xl) !important;
 }
 
+:host(.wp-block-button) {
+  height: auto;
+}
+
+:host(.wp-block-button) .vaadin-button-container {
+  height: auto;
+  overflow: visible;
+}
+
 :host(.wp-block-button) [part="label"] {
   white-space: normal;
   overflow: visible;
   text-overflow: unset;
+  padding-block: 0.5em;
 }
 
 :host(.wide) {

--- a/packages/storybook/cxl-lumo-styles/elements.stories.js
+++ b/packages/storybook/cxl-lumo-styles/elements.stories.js
@@ -17,7 +17,7 @@ export default {
  * @returns {TemplateResult}
  * @constructor
  */
-export const VaadinButton = ({ Label }) => {
+export const VaadinButton = ({ Label, WrapText, WrapTheme }) => {
   document.body.removeAttribute('unresolved');
 
   return html`
@@ -59,8 +59,7 @@ export const VaadinButton = ({ Label }) => {
 
     <h6>Text Wrapping</h6>
     <div style="display: flex; gap: 1rem; flex-wrap: wrap; max-width: 320px;">
-      <vaadin-button class="wp-block-button" theme="primary large">Learn about CXL subscriptions and pricing</vaadin-button>
-      <vaadin-button class="wp-block-button" theme="secondary large">CXL for Teams</vaadin-button>
+      <vaadin-button class="wp-block-button" theme="${WrapTheme}">${WrapText}</vaadin-button>
     </div>
 
     <h6>Upstream</h6>
@@ -76,6 +75,28 @@ export const VaadinButton = ({ Label }) => {
 Object.assign(VaadinButton, {
   args: {
     Label: 'Button',
+    WrapText: 'Learn about CXL subscriptions and pricing',
+    WrapTheme: 'primary large',
+  },
+  argTypes: {
+    WrapTheme: {
+      control: {
+        type: 'select',
+        options: [
+          'primary small',
+          'primary',
+          'primary large',
+          'primary x-large',
+          'primary contrast',
+          'primary large contrast',
+          'secondary',
+          'secondary large',
+          'secondary x-large',
+          'secondary contrast',
+          'secondary large contrast',
+        ],
+      },
+    },
   },
   storyName: 'vaadin-button',
 });

--- a/packages/storybook/cxl-lumo-styles/elements.stories.js
+++ b/packages/storybook/cxl-lumo-styles/elements.stories.js
@@ -49,6 +49,20 @@ export const VaadinButton = ({ Label }) => {
       >${Label} <vaadin-icon icon="cxl:linkedin" slot="prefix"></vaadin-icon
     ></vaadin-button>
 
+    <h6>Sizes</h6>
+    <div style="display: flex; align-items: center; gap: 1rem; flex-wrap: wrap;">
+      <vaadin-button theme="primary small">Small</vaadin-button>
+      <vaadin-button theme="primary">Medium</vaadin-button>
+      <vaadin-button theme="primary large">Large</vaadin-button>
+      <vaadin-button theme="primary x-large">X-Large</vaadin-button>
+    </div>
+
+    <h6>Text Wrapping</h6>
+    <div style="display: flex; gap: 1rem; flex-wrap: wrap; max-width: 320px;">
+      <vaadin-button class="wp-block-button" theme="primary large">Learn about CXL subscriptions and pricing</vaadin-button>
+      <vaadin-button class="wp-block-button" theme="secondary large">CXL for Teams</vaadin-button>
+    </div>
+
     <h6>Upstream</h6>
     <p>
       Also see


### PR DESCRIPTION
## Summary

- **Even size progression**: x-large now uses `--lumo-size-xl` (56px) instead of `*1.25` (70px), giving a consistent height step: 30 → 36 → 44 → 56px. Font size updated to `--lumo-font-size-xl` (22px).
- **Text wrapping on mobile**: Fixed button text overflowing its boundary on mobile. Root cause was Vaadin's internal shadow DOM setting a fixed `height` on `:host` — overridden with `height: auto` at higher specificity, plus `overflow: visible` on the container and `padding-block` on the label for breathing room.
- **Secondary contrast**: Added inverted colors (dark background, light text) for `secondary + contrast` theme combo — previously looked identical to secondary.
- **Bug fix**: `[theme="x-large"]` → `[theme~="x-large"]` to correctly match combined themes like `theme="primary x-large"`.
- **Storybook**: Added a sizes section showing all four sizes side by side, and a text wrapping section with live controls for CTA text and theme (primary/secondary/size/contrast combinations).

## Test plan

- [x] Check small, medium, large, x-large buttons render with even size steps
- [x] Check button text wraps correctly on mobile instead of overflowing
- [x] Check secondary vs secondary contrast buttons look visually distinct
- [ ] Check homepage button (`cxl-homepage-button`) still renders correctly
- [x] Check storybook sizes section shows all four sizes inline
- [x] Check storybook text wrapping controls — edit text and switch themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)